### PR TITLE
scripts: add slow flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ test   :; forge test -vvv
 test-contract :; forge test --match-contract ${filter} -vvv
 
 # Deploy
-deploy-ledger :; forge script ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv,--broadcast --ledger --mnemonics foo --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify -vvvv)
-deploy-pk :; forge script ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv,--broadcast --private-key ${PRIVATE_KEY} --verify -vvvv)
+deploy-ledger :; forge script ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv,--broadcast --ledger --mnemonics foo --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify -vvvv --slow)
+deploy-pk :; forge script ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv,--broadcast --private-key ${PRIVATE_KEY} --verify -vvvv --slow)
 
 
 # Utilities


### PR DESCRIPTION
aci deployed payload twice, while we cannot reproduce how it happened, it might be possible that it was related to getting some sort of error because 1st txn was not yet confirmed or so adding --slow doesn't make things dramatically slower, but ensures there are no availability issues