### PR TITLE
Chaos Labs Risk Parameter Updates - Increase MKR Debt Ceiling on V3 Ethereum

### DIFF
--- a/diffs/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116_before_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116_after.md
+++ b/diffs/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116_before_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116_after.md
@@ -1,0 +1,25 @@
+## Reserve changes
+
+### Reserves altered
+
+#### MKR ([0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2](https://etherscan.io/address/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2))
+
+| description | value before | value after |
+| --- | --- | --- |
+| debtCeiling | 6,000,000 $ | 8,500,000 $ |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2": {
+      "debtCeiling": {
+        "from": 600000000,
+        "to": 850000000
+      }
+    }
+  }
+}
+```

--- a/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.sol
+++ b/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3PayloadEthereum} from 'aave-helpers/v3-config-engine/AaveV3PayloadEthereum.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title Chaos Labs Risk Parameter Updates - Increase MKR Debt Ceiling on V3 Ethereum
+ * @author Chaos Labs
+ * - Snapshot: https://snapshot.org/\#/aave.eth/proposal/0xb3163709f822b662241395c1fde5ecaa8b39d52b1bc81722136c6084a4b3959c
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-mkr-debt-ceiling-on-v3-ethereum-11-07-2023/15406
+ */
+contract AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116 is
+  AaveV3PayloadEthereum
+{
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumAssets.MKR_UNDERLYING,
+      ltv: EngineFlags.KEEP_CURRENT,
+      liqThreshold: EngineFlags.KEEP_CURRENT,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: 8_500_000,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+
+    return collateralUpdate;
+  }
+}

--- a/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.t.sol
+++ b/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116} from './AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116
+ * command: make test-contract filter=AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116
+ */
+contract AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116_Test is
+  ProtocolV3TestBase
+{
+  AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116
+    internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18585531);
+    proposal = new AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    (ReserveConfig[] memory allConfigsBefore, ReserveConfig[] memory allConfigsAfter) = defaultTest(
+      'AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+
+    ReserveConfig memory MKR_UNDERLYING_CONFIG = _findReserveConfig(
+      allConfigsBefore,
+      AaveV3EthereumAssets.MKR_UNDERLYING
+    );
+    MKR_UNDERLYING_CONFIG.debtCeiling = 8_500_000_00;
+    _validateReserveConfig(MKR_UNDERLYING_CONFIG, allConfigsAfter);
+  }
+}

--- a/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum.md
+++ b/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum.md
@@ -1,0 +1,49 @@
+---
+title: "Chaos Labs Risk Parameter Updates - Increase MKR Debt Ceiling on V3 Ethereum"
+author: "Chaos Labs (@yonikesel, @ori-chaoslabs)"
+discussions: "https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-mkr-debt-ceiling-on-v3-ethereum-11-07-2023/15406"
+---
+
+## Simple Summary
+
+A proposal to increase the debt ceiling of MKR on V3 Ethereum
+
+## Motivation
+
+The current debt ceiling for MKR on V3 Ethereum, set at $6M, has reached 100% utilization.
+
+Given current market conditions and improved liquidity for MKR on Ethereum over the past months, our [Isolation Mode Methodology](https://governance.aave.com/t/chaos-labs-isolation-mode-methodology/12440) supports increasing the debt ceiling for MKR to $8.5M.
+
+It is important to note that the majority of MKR debt positions are concentrated within two accounts, accounting for over 80% of the total debt, as outlined below. While this concentration does not affect the current recommendation, it is something to continue monitoring and will be considered in future MKR recommendations and in cases of significant market changes.
+
+### V2 → V3 Migration
+
+There are still nearly 3,400 MKR supplied on V2 Ethereum, with nearly $750K in stablecoins borrowed against MKR collateral. The current supply caps and proposed debt ceiling should allow for the migration of these positions.
+
+### Positions Analysis
+
+There are currently two major users utilizing MKR as collateral on V3 Ethereum:
+
+1. [0xa9dee54892713f43c221509cfedbd717d16791a0](https://community-staging.chaoslabs.xyz/aave/risk/wallets/0xa9dee54892713f43c221509cfedbd717d16791a0) - borrowing $3.11M DAI against his 5,914 MKR collateral, accounting for nearly 52% of the debt ceiling. The user's current health score is 1.77.
+2. [0x8af700ba841f30e0a3fcb0ee4c4a9d223e1efa05](https://community-staging.chaoslabs.xyz/aave/risk/wallets/0x8af700ba841f30e0a3fcb0ee4c4a9d223e1efa05) - borrowing $1.84M USDC against his 4,077 MKR collateral, accounting for nearly 31% of the debt ceiling. The user's current health score is 2.06.
+
+## Specification
+
+| Asset | Parameter    | Current   | Recommended |
+| ----- | ------------ | --------- | ----------- |
+| MKR   | Debt Ceiling | 6,000,000 | 8,500,000   |
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.t.sol)
+- [Snapshot](https://snapshot.org/#/aave.eth/proposal/0xb3163709f822b662241395c1fde5ecaa8b39d52b1bc81722136c6084a4b3959c)
+- [Discussion](https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-mkr-debt-ceiling-on-v3-ethereum-11-07-2023/15406)
+
+## Disclaimer
+
+Chaos Labs has not been compensated by any third party for publishing this ARFC.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.s.sol
+++ b/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.s.sol
@@ -36,7 +36,7 @@ contract CreateProposal is EthereumScript {
     // compose actions for validation
     IPayloadsControllerCore.ExecutionAction[]
       memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
-    actionsEthereum[0] = GovV3Helpers.buildAction(address(0));
+    actionsEthereum[0] = GovV3Helpers.buildAction(0xb1dA0D9bBC23A602145C9Efaf81ADD188B206d88);
     payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
 
     // create proposal

--- a/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.s.sol
+++ b/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/GovV3Helpers.sol';
+import {EthereumScript} from 'aave-helpers/ScriptUtils.sol';
+import {AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116} from './AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * command: make deploy-ledger contract=src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.s.sol:DeployEthereum chain=mainnet
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116 payload0 = new AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116();
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(address(payload0));
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum_20231116.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(address(0));
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal2_5(
+      vm,
+      payloads,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum.md'
+      )
+    );
+  }
+}

--- a/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/config.json
+++ b/src/20231116_AaveV3Ethereum_ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum/config.json
@@ -1,0 +1,32 @@
+{
+  "rootOptions": {
+    "author": "Chaos Labs",
+    "title": "Chaos Labs Risk Parameter Updates - Increase MKR Debt Ceiling on V3 Ethereum",
+    "discussion": "https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-mkr-debt-ceiling-on-v3-ethereum-11-07-2023/15406",
+    "snapshot": "https://snapshot.org/\\#/aave.eth/proposal/0xb3163709f822b662241395c1fde5ecaa8b39d52b1bc81722136c6084a4b3959c",
+    "pools": [
+      "AaveV3Ethereum"
+    ],
+    "shortName": "ChaosLabsRiskParameterUpdatesIncreaseMKRDebtCeilingOnV3Ethereum",
+    "date": "20231116"
+  },
+  "poolOptions": {
+    "AaveV3Ethereum": {
+      "configs": {
+        "COLLATERALS_UPDATE": [
+          {
+            "asset": "MKR",
+            "ltv": "EngineFlags.KEEP_CURRENT",
+            "liqThreshold": "EngineFlags.KEEP_CURRENT",
+            "liqBonus": "EngineFlags.KEEP_CURRENT",
+            "debtCeiling": "8_500_000",
+            "liqProtocolFee": "EngineFlags.KEEP_CURRENT"
+          }
+        ]
+      },
+      "features": [
+        "COLLATERALS_UPDATE"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-mkr-debt-ceiling-on-v3-ethereum-11-07-2023/15406