### PR TITLE
Pass pool identifier since it's not officially part of PoolConfig

### DIFF
--- a/generator/generator.ts
+++ b/generator/generator.ts
@@ -40,9 +40,9 @@ export async function generateFiles(options: Options, poolConfigs: PoolConfigs):
 
   function createPayloadAndTest(options: Options, pool: PoolIdentifier) {
     const contractName = generateContractName(options, pool);
-    const testCode = testTemplate(options, poolConfigs[pool]!);
+    const testCode = testTemplate(options, poolConfigs[pool]!, pool);
     return {
-      payload: prettier.format(proposalTemplate(options, poolConfigs[pool]!), {
+      payload: prettier.format(proposalTemplate(options, poolConfigs[pool]!, pool), {
         ...prettierSolCfg,
         filepath: 'foo.sol',
       }),

--- a/generator/templates/proposal.template.ts
+++ b/generator/templates/proposal.template.ts
@@ -1,13 +1,17 @@
 import {generateContractName, getPoolChain, getVersion} from '../common';
-import {FEATURE, Options, PoolConfig} from '../types';
+import {FEATURE, Options, PoolConfig, PoolIdentifier} from '../types';
 import {prefixWithImports} from '../utils/importsResolver';
 import {prefixWithPragma} from '../utils/constants';
 
-export const proposalTemplate = (options: Options, poolConfig: PoolConfig) => {
+export const proposalTemplate = (
+  options: Options,
+  poolConfig: PoolConfig,
+  pool: PoolIdentifier
+) => {
   const {title, author, snapshot, discussion} = options;
-  const chain = getPoolChain(poolConfig.pool);
-  const version = getVersion(poolConfig.pool);
-  const contractName = generateContractName(options, poolConfig.pool);
+  const chain = getPoolChain(pool);
+  const version = getVersion(pool);
+  const contractName = generateContractName(options, pool);
 
   const constants = poolConfig.artifacts
     .map((artifact) => artifact.code?.constants)

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -1,13 +1,13 @@
 import {generateContractName, getChainAlias, getPoolChain, isV2Pool} from '../common';
-import {Options, PoolConfig} from '../types';
+import {Options, PoolConfig, PoolIdentifier} from '../types';
 import {prefixWithPragma} from '../utils/constants';
 import {prefixWithImports} from '../utils/importsResolver';
 
-export const testTemplate = (options: Options, poolConfig: PoolConfig) => {
-  const chain = getPoolChain(poolConfig.pool);
-  const contractName = generateContractName(options, poolConfig.pool);
+export const testTemplate = (options: Options, poolConfig: PoolConfig, pool: PoolIdentifier) => {
+  const chain = getPoolChain(pool);
+  const contractName = generateContractName(options, pool);
 
-  const testBase = isV2Pool(poolConfig.pool) ? 'ProtocolV2TestBase' : 'ProtocolV3TestBase';
+  const testBase = isV2Pool(pool) ? 'ProtocolV2TestBase' : 'ProtocolV3TestBase';
 
   const functions = poolConfig.artifacts
     .map((artifact) => artifact.test?.fn)
@@ -36,7 +36,7 @@ contract ${contractName}_Test is ${testBase} {
    * @dev executes the generic test suite including e2e and config snapshots
    */
   function test_defaultProposalExecution() public {
-    defaultTest('${contractName}', ${poolConfig.pool}.POOL, address(proposal));
+    defaultTest('${contractName}', ${pool}.POOL, address(proposal));
   }
 
   ${functions}


### PR DESCRIPTION
This was resulting in errors when trying to regenerate a proposal using a config.json file - but interestingly did not trigger when using the interactive CLI.

I believe this stems from the inclusion of the pool as an attribute of PoolConfig here https://github.com/GauntletNetworks/aave-proposals-v3/blob/a5696e02b847c90f238a55323987c95d3bacc270/generator/cli.ts#L153, but this actually clashes with the type definition of PoolConfig which doesn't include this field.