### PR TITLE
Fix a variety of small type errors so tsc runs cleanly

### DIFF
--- a/generator/cli.ts
+++ b/generator/cli.ts
@@ -142,7 +142,7 @@ if (options.configFile) {
 
   async function generateDeterministicPoolCache(pool: PoolIdentifier): Promise<PoolCache> {
     const chain = getPoolChain(pool);
-    const client = CHAIN_ID_CLIENT_MAP[CHAIN_TO_CHAIN_ID[chain]] as PublicClient;
+    const client = CHAIN_ID_CLIENT_MAP[CHAIN_TO_CHAIN_ID[chain]!] as PublicClient;
     return {blockNumber: Number(await client.getBlockNumber())};
   }
 

--- a/generator/cli.ts
+++ b/generator/cli.ts
@@ -88,7 +88,7 @@ if (options.configFile) {
         module.build({
           options,
           pool,
-          cfg: poolConfigs[pool]!.configs[feature],
+          cfg: poolConfigs[pool]!.configs[feature as FEATURE],
           cache: poolConfigs[pool]!.cache,
         })
       );

--- a/generator/common.ts
+++ b/generator/common.ts
@@ -10,6 +10,8 @@ import {
   base,
   bsc,
   gnosis,
+  fantom,
+  harmonyOne,
 } from 'viem/chains';
 
 export const AVAILABLE_CHAINS = [
@@ -25,6 +27,8 @@ export const AVAILABLE_CHAINS = [
   'Bsc',
   'Gnosis',
 ] as const;
+
+export type Chain = (typeof AVAILABLE_CHAINS)[number];
 
 export function getAssets(pool: PoolIdentifier): string[] {
   const assets = addressBook[pool].ASSETS;
@@ -82,7 +86,7 @@ export function generateContractName(options: Options, pool?: PoolIdentifier) {
   return name;
 }
 
-export function getChainAlias(chain) {
+export function getChainAlias(chain: Chain) {
   return chain === 'Ethereum' ? 'mainnet' : chain.toLowerCase();
 }
 
@@ -105,6 +109,8 @@ export const CHAIN_TO_CHAIN_ID = {
   Base: base.id,
   Bsc: bsc.id,
   Gnosis: gnosis.id,
+  Fantom: fantom.id,
+  Harmony: harmonyOne.id,
 };
 
 export function flagAsRequired(message: string, required?: boolean) {

--- a/generator/common.ts
+++ b/generator/common.ts
@@ -10,8 +10,6 @@ import {
   base,
   bsc,
   gnosis,
-  fantom,
-  harmonyOne,
 } from 'viem/chains';
 
 export const AVAILABLE_CHAINS = [

--- a/generator/common.ts
+++ b/generator/common.ts
@@ -99,7 +99,7 @@ export function pascalCase(str: string) {
     .replace(/ /g, '');
 }
 
-export const CHAIN_TO_CHAIN_ID = {
+export const CHAIN_TO_CHAIN_ID: Partial<Record<Chain, number>> = {
   Ethereum: mainnet.id,
   Polygon: polygon.id,
   Optimism: optimism.id,
@@ -109,8 +109,6 @@ export const CHAIN_TO_CHAIN_ID = {
   Base: base.id,
   Bsc: bsc.id,
   Gnosis: gnosis.id,
-  Fantom: fantom.id,
-  Harmony: harmonyOne.id,
 };
 
 export function flagAsRequired(message: string, required?: boolean) {

--- a/generator/features/assetListing.ts
+++ b/generator/features/assetListing.ts
@@ -49,7 +49,7 @@ async function fetchListing(pool: PoolIdentifier): Promise<Listing> {
         type: 'function',
       },
     ],
-    publicClient: CHAIN_ID_CLIENT_MAP[CHAIN_TO_CHAIN_ID[chain]] as PublicClient,
+    publicClient: CHAIN_ID_CLIENT_MAP[CHAIN_TO_CHAIN_ID[chain]!] as PublicClient,
     address: asset,
   });
   let symbol = '';

--- a/generator/features/collateralsUpdates.ts
+++ b/generator/features/collateralsUpdates.ts
@@ -1,5 +1,4 @@
 import {CodeArtifact, FEATURE, FeatureModule, PoolIdentifier} from '../types';
-import {percentInput} from '../prompts';
 import {CollateralUpdate, CollateralUpdatePartial} from './types';
 import {
   assetsSelectPrompt,

--- a/generator/features/types.ts
+++ b/generator/features/types.ts
@@ -1,5 +1,6 @@
 import {Hex} from 'viem';
-import {BooleanSelectValues, NumberInputValues, PercentInputValues} from '../prompts';
+import {NumberInputValues, PercentInputValues} from '../prompts';
+import {BooleanSelectValues} from '../prompts/boolPrompt';
 
 export interface AssetSelector {
   asset: string;

--- a/generator/generator.ts
+++ b/generator/generator.ts
@@ -32,7 +32,7 @@ export async function generateFiles(options: Options, poolConfigs: PoolConfigs):
       poolOptions: (Object.keys(poolConfigs) as PoolIdentifier[]).reduce((acc, pool) => {
         acc[pool] = {configs: poolConfigs[pool]!.configs, cache: poolConfigs[pool]!.cache};
         return acc;
-      }, {}),
+      }, {} as ConfigFile['poolOptions']),
     } as ConfigFile,
     null,
     2

--- a/generator/index.d.ts
+++ b/generator/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'prettier';

--- a/generator/prompts.spec.ts
+++ b/generator/prompts.spec.ts
@@ -14,7 +14,7 @@ import {
 describe('prompts', () => {
   describe('numberInput', () => {
     it('handles "yes"', async () => {
-      const {answer, events, getScreen} = await render(numberPrompt, {
+      const {answer, events, getScreen} = await render(numberPrompt as any, {
         message: 'Enter number?',
       });
 
@@ -30,7 +30,7 @@ describe('prompts', () => {
 
   describe('percentInput', () => {
     it('handles "yes"', async () => {
-      const {answer, events, getScreen} = await render(percentPrompt, {
+      const {answer, events, getScreen} = await render(percentPrompt as any, {
         message: 'Enter number?',
       });
 

--- a/generator/prompts.ts
+++ b/generator/prompts.ts
@@ -16,10 +16,6 @@ interface GenericPrompt<T extends boolean = boolean> {
   defaultValue?: string;
 }
 
-interface PercentInputPrompt<T extends boolean> extends GenericPrompt<T> {
-  toRay?: boolean;
-}
-
 export type PercentInputValues = typeof ENGINE_FLAGS.KEEP_CURRENT | string;
 
 export type NumberInputValues = typeof ENGINE_FLAGS.KEEP_CURRENT | string;

--- a/generator/prompts/addressPrompt.spec.ts
+++ b/generator/prompts/addressPrompt.spec.ts
@@ -5,7 +5,7 @@ import {addressPrompt, translateJsAddressToSol} from './addressPrompt';
 describe('addresses', () => {
   describe('addressPrompt', () => {
     it('handles "required"', async () => {
-      const {answer, events, getScreen} = await render(addressPrompt, {
+      const {answer, events, getScreen} = await render(addressPrompt as any, {
         message: 'Enter address?',
         required: true,
       });
@@ -28,7 +28,7 @@ describe('addresses', () => {
     });
 
     it('handles "optional"', async () => {
-      const {answer, events, getScreen} = await render(addressPrompt, {
+      const {answer, events, getScreen} = await render(addressPrompt as any, {
         message: 'Enter address?',
       });
 

--- a/generator/prompts/addressPrompt.ts
+++ b/generator/prompts/addressPrompt.ts
@@ -2,10 +2,11 @@ import {Hex, getAddress, isAddress} from 'viem';
 import {GenericPrompt} from './types';
 import {advancedInput} from './advancedInput';
 import {flagAsRequired} from '../common';
+import {Context} from '@inquirer/type';
 
 export async function addressPrompt<T extends boolean>(
   {message, required}: GenericPrompt<T>,
-  opts?
+  opts?: Context
 ): Promise<T extends true ? Hex : Hex | ''> {
   const value = await advancedInput(
     {

--- a/generator/prompts/numberPrompt.ts
+++ b/generator/prompts/numberPrompt.ts
@@ -1,3 +1,4 @@
+import {Context} from '@inquirer/type';
 import {advancedInput} from './advancedInput';
 import {GenericPrompt} from './types';
 
@@ -12,7 +13,7 @@ export function transformNumberToHumanReadable(value: string) {
   return value;
 }
 
-export async function numberPrompt({message, required}: GenericPrompt, opts?) {
+export async function numberPrompt({message, required}: GenericPrompt, opts?: Context) {
   return await advancedInput(
     {
       message,

--- a/generator/prompts/percentPrompt.ts
+++ b/generator/prompts/percentPrompt.ts
@@ -1,3 +1,4 @@
+import {Context} from '@inquirer/type';
 import {advancedInput} from './advancedInput';
 import {GenericPrompt} from './types';
 
@@ -18,7 +19,7 @@ export function transformNumberToPercent(value: string) {
 
 export async function percentPrompt<T extends boolean>(
   {message, required}: GenericPrompt<T>,
-  opts?
+  opts?: Context
 ): Promise<string> {
   const value = await advancedInput(
     {

--- a/generator/prompts/stringPrompt.ts
+++ b/generator/prompts/stringPrompt.ts
@@ -1,10 +1,11 @@
+import {Context} from '@inquirer/type';
 import {flagAsRequired} from '../common';
 import {advancedInput} from './advancedInput';
 import {GenericPrompt} from './types';
 
 export async function stringPrompt<T extends boolean>(
   {message, defaultValue, required}: GenericPrompt<T>,
-  opts?
+  opts?: Context
 ) {
   return advancedInput(
     {

--- a/generator/templates/proposal.template.ts
+++ b/generator/templates/proposal.template.ts
@@ -31,10 +31,10 @@ export const proposalTemplate = (
 
   let optionalExecute = '';
   const usesConfigEngine = Object.keys(poolConfig.configs).some(
-    (f) => ![FEATURE.OTHERS, FEATURE.FLASH_BORROWER].includes(f)
+    (f) => ![FEATURE.OTHERS, FEATURE.FLASH_BORROWER].includes(f as FEATURE)
   );
   const isAssetListing = Object.keys(poolConfig.configs).some((f) =>
-    [FEATURE.ASSET_LISTING, FEATURE.ASSET_LISTING_CUSTOM].includes(f)
+    [FEATURE.ASSET_LISTING, FEATURE.ASSET_LISTING_CUSTOM].includes(f as FEATURE)
   );
   if (innerExecute) {
     if (usesConfigEngine) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@inquirer/testing": "^2.1.9",
     "commander": "^11.1.0",
     "tsx": "^3.14.0",
+    "typescript": "^5.3.2",
     "viem": "^1.18.9"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,6 @@
     "sourceMap": true,
     "resolveJsonModule": true,
   },
-  "ts-node": {
-    "esm": true
-  },
   "include": [
     "generator/**/*"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+  },
+  "ts-node": {
+    "esm": true
+  },
+  "include": [
+    "generator/**/*"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,6 +1791,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+typescript@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
+  integrity sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==
+
 ufo@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.1.tgz#e085842f4627c41d4c1b60ebea1f75cdab4ce86b"


### PR DESCRIPTION
When combined with https://github.com/bgd-labs/aave-cli/pull/77 this makes it so `yarn run tsc --noEmit` runs cleanly!

Would be good to add this to CI, I noticed that the vitests are also outdated (there are snapshot errors when running `yarn test`) and I see that's also not run in CI right now.

Also includes #96, which is related