### PR TITLE
Treasury Management - Transfer CRV to GLC SAFE

### DIFF
--- a/src/20231122_AaveV3Optimism_OnboardNativeUSDCToAaveV3Optimism/config.json
+++ b/src/20231122_AaveV3Optimism_OnboardNativeUSDCToAaveV3Optimism/config.json
@@ -1,8 +1,6 @@
 {
   "rootOptions": {
-    "pools": [
-      "AaveV3Optimism"
-    ],
+    "pools": ["AaveV3Optimism"],
     "title": "Onboard Native USDC to Aave V3 Optimism",
     "shortName": "OnboardNativeUSDCToAaveV3Optimism",
     "date": "20231122",

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.19;
+
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGenericExecutor.sol';
+
+/**
+ * @title Redeem CRV from AaveV2Ethereum and Transfer to GLC
+ * @author efecarranza.eth
+ * - Snapshot: TODO
+ * - Discussion: TODO
+ */
+contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 is
+  IProposalGenericExecutor
+{
+  address public constant GLC_SAFE = 0x205e795336610f5131Be52F09218AF19f0f3eC60;
+
+  function execute() external {
+    AaveV2Ethereum.COLLECTOR.transfer(
+      AaveV2EthereumAssets.CRV_A_TOKEN,
+      address(this),
+      IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV2Ethereum.COLLECTOR))
+    );
+
+    AaveV2Ethereum.COLLECTOR.transfer(
+      AaveV2EthereumAssets.CRV_UNDERLYING,
+      address(this),
+      IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR))
+    );
+
+    AaveV2Ethereum.POOL.withdraw(
+      AaveV2EthereumAssets.CRV_UNDERLYING,
+      type(uint256).max,
+      address(this)
+    );
+
+    IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).transfer(
+      GLC_SAFE,
+      IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(this))
+    );
+  }
+}

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
@@ -37,16 +37,8 @@ contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 is
       IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR))
     );
 
-    AaveV2Ethereum.POOL.withdraw(
-      AaveV2EthereumAssets.CRV_UNDERLYING,
-      type(uint256).max,
-      GLC_SAFE
-    );
+    AaveV2Ethereum.POOL.withdraw(AaveV2EthereumAssets.CRV_UNDERLYING, type(uint256).max, GLC_SAFE);
 
-    AaveV3Ethereum.POOL.withdraw(
-      AaveV3EthereumAssets.CRV_UNDERLYING,
-      type(uint256).max,
-      GLC_SAFE
-    );
+    AaveV3Ethereum.POOL.withdraw(AaveV3EthereumAssets.CRV_UNDERLYING, type(uint256).max, GLC_SAFE);
   }
 }

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
@@ -4,13 +4,14 @@ pragma solidity 0.8.19;
 
 import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
 import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGenericExecutor.sol';
 
 /**
  * @title Redeem CRV from AaveV2Ethereum and Transfer to GLC
  * @author efecarranza.eth
- * - Snapshot: TODO
- * - Discussion: TODO
+ * - Snapshot: https://snapshot.org/#/aave.eth/proposal/0xf92c5647c7f60a4a3db994b4953fc4408f5946cafdc0cebcd4c5924f40e04d36
+ * - Discussion: https://governance.aave.com/t/arfc-deploy-acrv-crv-to-vecrv/11628
  */
 contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 is
   IProposalGenericExecutor
@@ -25,6 +26,12 @@ contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 is
     );
 
     AaveV2Ethereum.COLLECTOR.transfer(
+      AaveV3EthereumAssets.CRV_A_TOKEN,
+      address(this),
+      IERC20(AaveV3EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV3Ethereum.COLLECTOR))
+    );
+
+    AaveV2Ethereum.COLLECTOR.transfer(
       AaveV2EthereumAssets.CRV_UNDERLYING,
       address(this),
       IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR))
@@ -32,6 +39,12 @@ contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 is
 
     AaveV2Ethereum.POOL.withdraw(
       AaveV2EthereumAssets.CRV_UNDERLYING,
+      type(uint256).max,
+      address(this)
+    );
+
+    AaveV3Ethereum.POOL.withdraw(
+      AaveV3EthereumAssets.CRV_UNDERLYING,
       type(uint256).max,
       address(this)
     );

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol
@@ -33,25 +33,20 @@ contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 is
 
     AaveV2Ethereum.COLLECTOR.transfer(
       AaveV2EthereumAssets.CRV_UNDERLYING,
-      address(this),
+      GLC_SAFE,
       IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR))
     );
 
     AaveV2Ethereum.POOL.withdraw(
       AaveV2EthereumAssets.CRV_UNDERLYING,
       type(uint256).max,
-      address(this)
+      GLC_SAFE
     );
 
     AaveV3Ethereum.POOL.withdraw(
       AaveV3EthereumAssets.CRV_UNDERLYING,
       type(uint256).max,
-      address(this)
-    );
-
-    IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).transfer(
-      GLC_SAFE,
-      IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(this))
+      GLC_SAFE
     );
   }
 }

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.t.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.19;
+
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {ProtocolV2TestBase, ReserveConfig} from 'aave-helpers/ProtocolV2TestBase.sol';
+
+import {AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123} from './AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol';
+
+/**
+ * @dev Test for AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123
+ * command: make test-contract filter=AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123
+ */
+contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123_Test is
+  ProtocolV2TestBase
+{
+  AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18635076);
+    proposal = new AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123();
+  }
+
+  function test_execute() public {
+    uint256 balanceCollectorCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR));
+    uint256 balanceCollectorACRVBefore = IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV2Ethereum.COLLECTOR));
+    uint256 balanceProposalCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(proposal));
+    uint256 balanceGLCCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE());
+
+    assertEq(balanceProposalCRVBefore, 0);
+
+    GovV3Helpers.executePayload(vm, address(proposal));
+
+    assertEq(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(proposal)), 0);
+    
+    assertEq(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR)), 0);
+    assertLt(IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV2Ethereum.COLLECTOR)), 100 ether);
+
+    assertGt(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE()), balanceGLCCRVBefore);
+    assertApproxEqRel(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE()), balanceGLCCRVBefore + balanceCollectorACRVBefore + balanceCollectorCRVBefore, 100 ether);
+  }
+}

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.t.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.t.sol
@@ -5,7 +5,8 @@ pragma solidity 0.8.19;
 import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
 import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
 import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
-import {ProtocolV2TestBase, ReserveConfig} from 'aave-helpers/ProtocolV2TestBase.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {ProtocolV2TestBase} from 'aave-helpers/ProtocolV2TestBase.sol';
 
 import {AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123} from './AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol';
 
@@ -19,26 +20,57 @@ contract AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123_Tes
   AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 internal proposal;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 18635076);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18720612);
     proposal = new AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123();
   }
 
   function test_execute() public {
-    uint256 balanceCollectorCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR));
-    uint256 balanceCollectorACRVBefore = IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV2Ethereum.COLLECTOR));
-    uint256 balanceProposalCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(proposal));
-    uint256 balanceGLCCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE());
+    uint256 balanceCollectorCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(
+      address(AaveV2Ethereum.COLLECTOR)
+    );
+    uint256 balanceCollectorACRVBefore = IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(
+      address(AaveV2Ethereum.COLLECTOR)
+    );
+    uint256 balanceCollectorAEthCRVBefore = IERC20(AaveV3EthereumAssets.CRV_A_TOKEN).balanceOf(
+      address(AaveV2Ethereum.COLLECTOR)
+    );
+    uint256 balanceProposalCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(
+      address(proposal)
+    );
+    uint256 balanceGLCCRVBefore = IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(
+      proposal.GLC_SAFE()
+    );
 
     assertEq(balanceProposalCRVBefore, 0);
 
     GovV3Helpers.executePayload(vm, address(proposal));
 
     assertEq(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(proposal)), 0);
-    
-    assertEq(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR)), 0);
-    assertLt(IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV2Ethereum.COLLECTOR)), 100 ether);
 
-    assertGt(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE()), balanceGLCCRVBefore);
-    assertApproxEqRel(IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE()), balanceGLCCRVBefore + balanceCollectorACRVBefore + balanceCollectorCRVBefore, 100 ether);
+    assertEq(
+      IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(address(AaveV2Ethereum.COLLECTOR)),
+      0
+    );
+    assertLt(
+      IERC20(AaveV2EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV2Ethereum.COLLECTOR)),
+      350 ether
+    );
+    assertEq(
+      IERC20(AaveV3EthereumAssets.CRV_A_TOKEN).balanceOf(address(AaveV3Ethereum.COLLECTOR)),
+      0
+    );
+
+    assertGt(
+      IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE()),
+      balanceGLCCRVBefore
+    );
+    assertApproxEqRel(
+      IERC20(AaveV2EthereumAssets.CRV_UNDERLYING).balanceOf(proposal.GLC_SAFE()),
+      balanceGLCCRVBefore +
+        balanceCollectorACRVBefore +
+        balanceCollectorCRVBefore +
+        balanceCollectorAEthCRVBefore,
+      100 ether
+    );
   }
 }

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md
@@ -1,7 +1,7 @@
 ---
-title: "Redeem CRV from AaveV2Ethereum and Transfer to GLC"
-author: "karpatkey_TokenLogic - MatthewGraham, Sisyphos & efecarranza"
-discussions: ""
+title: "Transfer all CRV positions from Ethereum Mainnet Collector to GLC Safe"
+author: "TokenLogic & karpatkey"
+discussions: "https://governance.aave.com/t/arfc-deploy-acrv-crv-to-vecrv/11628"
 ---
 
 ## Simple Summary
@@ -27,10 +27,10 @@ The GLC is then expected to manage the sdCRV holdings to the benefit of the DAO 
 This proposal encompasses the following actions:
 
 - Transfer aEthCRV (Aave V3) & aCRV (AaveV2) from Collector to Proposal Payload contract
-- Withdraw aEthCRV (Aave V3) & aCRV (Aave V2) from Ethereum Mainnet on the Proposal Payload contract
-- Transfer all newly available Ethereum Mainnet CRV to GLC SAFE
+- Withdraw aEthCRV (Aave V3) & aCRV (Aave V2) from Ethereum Mainnet on the Proposal Payload contract to GLC SAFE
+- Transfer existing CRV position on Ethereum Mainnet to GLC SAFE
 
-GLC SAFE Address: `0x205e795336610f5131Be52F09218AF19f0f3eC60`
+GLC SAFE Address: [`0x205e795336610f5131Be52F09218AF19f0f3eC60`](https://etherscan.io/address/0x205e795336610f5131Be52F09218AF19f0f3eC60)
 
 ## References
 

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md
@@ -1,0 +1,22 @@
+---
+title: "Redeem CRV from AaveV2Ethereum and Transfer to GLC"
+author: "TokenLogic"
+discussions: ""
+---
+
+## Simple Summary
+
+## Motivation
+
+## Specification
+
+## References
+
+- Implementation: [AaveV2Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol)
+- Tests: [AaveV2Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.t.sol)
+- [Snapshot](TODO)
+- [Discussion](TODO)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md
@@ -1,21 +1,43 @@
 ---
 title: "Redeem CRV from AaveV2Ethereum and Transfer to GLC"
-author: "TokenLogic"
+author: "karpatkey_TokenLogic - MatthewGraham, Sisyphos & efecarranza"
 discussions: ""
 ---
 
 ## Simple Summary
 
+Transfer all available CRV from Aave Mainnet Treasury to GHO Liquidity Committee (GLC) SAFE where it will be deployed to sdCRV.
+
 ## Motivation
 
+Upon implementation of this AIP, CRV will be withdrawn from Aave Protocol on Ethereum Mainnet (both V2 and V3) and all newly available CRV transferred to the GLC SAFE.
+
+- [aEthCRV](https://etherscan.io/token/0x7b95ec873268a6bfc6427e7a28e396db9d0ebc65?a=0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c) - 30,153.23 units at time of writing
+- [aCRV](https://etherscan.io/token/0x8dae6cb04688c62d939ed9b68d32bc62e49970b1?a=0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c) - 6,052,066.53 units at time of writing
+- [CRV](https://etherscan.io/token/0xD533a949740bb3306d119CC777fa900bA034cd52?a=0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c) - 29,247.71 units
+
+Total ~6,111,467.47 units of CRV
+
+The GLC is expected to mint and stake sdCRV with the CRV. At the time of writing, staked sdCRV is generating between 20.35% and 41.85% APR.
+
+The GLC is then expected to manage the sdCRV holdings to the benefit of the DAO with the primary focus of supporting GHO liquidity. The GLC is expected to make use of the vote-boosted sdCRV offering by StakeDAO. Details on vote-boosted sdCRV can be found [here](https://stakedaohq.medium.com/introducing-the-boosted-vote-strategy-the-best-way-to-get-boosted-voting-power-on-your-crv-22fc7ed52088).
+
 ## Specification
+
+This proposal encompasses the following actions:
+
+- Transfer aEthCRV (Aave V3) & aCRV (AaveV2) from Collector to Proposal Payload contract
+- Withdraw aEthCRV (Aave V3) & aCRV (Aave V2) from Ethereum Mainnet on the Proposal Payload contract
+- Transfer all newly available Ethereum Mainnet CRV to GLC SAFE
+
+GLC SAFE Address: `0x205e795336610f5131Be52F09218AF19f0f3eC60`
 
 ## References
 
 - Implementation: [AaveV2Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol)
 - Tests: [AaveV2Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.t.sol)
-- [Snapshot](TODO)
-- [Discussion](TODO)
+- [Snapshot](https://snapshot.org/#/aave.eth/proposal/0xf92c5647c7f60a4a3db994b4953fc4408f5946cafdc0cebcd4c5924f40e04d36)
+- [Discussion](https://governance.aave.com/t/arfc-deploy-acrv-crv-to-vecrv/11628)
 
 ## Copyright
 

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.s.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.s.sol
@@ -36,7 +36,7 @@ contract CreateProposal is EthereumScript {
     // compose actions for validation
     IPayloadsControllerCore.ExecutionAction[]
       memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
-    actionsEthereum[0] = GovV3Helpers.buildAction(address(0));
+    actionsEthereum[0] = GovV3Helpers.buildAction(0x66c6ba442D5947007263238bA8deDDE2Dc9fd855);
     payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
 
     // create proposal

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.s.sol
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/GovV3Helpers.sol';
+import {EthereumScript} from 'aave-helpers/ScriptUtils.sol';
+import {AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123} from './AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * command: make deploy-ledger contract=src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.s.sol:DeployEthereum chain=mainnet
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123 payload0 = new AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123();
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(address(payload0));
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC_20231123.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(address(0));
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal2_5(
+      vm,
+      payloads,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/RedeemCRVFromAaveV2EthereumAndTransferToGLC.md'
+      )
+    );
+  }
+}

--- a/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/config.json
+++ b/src/20231123_AaveV2Ethereum_RedeemCRVFromAaveV2EthereumAndTransferToGLC/config.json
@@ -1,0 +1,21 @@
+{
+  "rootOptions": {
+    "pools": ["AaveV2Ethereum"],
+    "title": "Redeem CRV from AaveV2Ethereum and Transfer to GLC",
+    "shortName": "RedeemCRVFromAaveV2EthereumAndTransferToGLC",
+    "date": "20231123",
+    "author": "TokenLogic",
+    "discussion": "",
+    "snapshot": ""
+  },
+  "poolOptions": {
+    "AaveV2Ethereum": {
+      "configs": {
+        "OTHERS": {}
+      },
+      "cache": {
+        "blockNumber": 18635076
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Changelog

Add proposal to withdraw CRV from Aave V2 and Aave V3 on Ethereum Mainnet.
Add tests for proposal.
Add README.