### PR TITLE
Treasury Management - Polygon v2 to v3 Migration

### DIFF
--- a/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.t.sol
+++ b/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.t.sol
@@ -19,8 +19,10 @@ contract AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208_Test is
   AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208 internal proposal;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('polygon'), 50991163);
-    proposal = new AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208();
+    vm.createSelectFork(vm.rpcUrl('polygon'), 51130199);
+    proposal = AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208(
+      0x31B7F31dcCF8E8127a6f1619e6624A2a5Ef6713B
+    );
   }
 
   function test_execute() public {

--- a/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.t.sol
+++ b/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.t.sol
@@ -24,9 +24,6 @@ contract AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208_Test is
   }
 
   function test_execute() public {
-    // Collector contract is same address across both files
-    assertEq(address(AaveV2Polygon.COLLECTOR), address(AaveV3Polygon.COLLECTOR));
-
     address[8] memory TO_MIGRATE = AddressesToMigrate.getUnderlyingAddresses();
     address[8] memory A_TOKENS = AddressesToMigrate.getV2ATokenAddresses();
 
@@ -45,20 +42,20 @@ contract AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208_Test is
     uint256[] memory v2Assetsbalances = new uint256[](8);
 
     for (uint256 i = 0; i < TO_MIGRATE.length; ++i) {
-      uint256 balanceV2 = IERC20(A_TOKENS[i]).balanceOf(address(AaveV2Polygon.COLLECTOR));
+      uint256 balanceV2 = IERC20(A_TOKENS[i]).balanceOf(address(AaveV3Polygon.COLLECTOR));
       uint256 balanceV3 = IERC20(V3_A_TOKENS[i]).balanceOf(address(AaveV3Polygon.COLLECTOR));
 
-      assertGt(IERC20(A_TOKENS[i]).balanceOf(address(AaveV2Polygon.COLLECTOR)), 0);
+      assertGt(IERC20(A_TOKENS[i]).balanceOf(address(AaveV3Polygon.COLLECTOR)), 0);
 
       v2Assetsbalances[i] = balanceV2;
       v3AssetsBalances[i] = balanceV3;
     }
 
     uint256 balanceUsdcBefore = IERC20(AaveV2PolygonAssets.USDC_UNDERLYING).balanceOf(
-      address(AaveV2Polygon.COLLECTOR)
+      address(AaveV3Polygon.COLLECTOR)
     );
     uint256 balanceWMaticBefore = IERC20(AaveV2PolygonAssets.WMATIC_UNDERLYING).balanceOf(
-      address(AaveV2Polygon.COLLECTOR)
+      address(AaveV3Polygon.COLLECTOR)
     );
 
     assertGt(balanceUsdcBefore, 0);
@@ -69,8 +66,8 @@ contract AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208_Test is
     assertEq(IERC20(AaveV2PolygonAssets.USDC_UNDERLYING).balanceOf(address(proposal)), 0);
     assertEq(IERC20(AaveV2PolygonAssets.WMATIC_UNDERLYING).balanceOf(address(proposal)), 0);
 
-    for (uint256 i = 0; i < TO_MIGRATE.length; ++i) {
-      uint256 balanceV2 = IERC20(A_TOKENS[i]).balanceOf(address(AaveV2Polygon.COLLECTOR));
+    for (uint256 i = 0; i < TO_MIGRATE.length; i++) {
+      uint256 balanceV2 = IERC20(A_TOKENS[i]).balanceOf(address(AaveV3Polygon.COLLECTOR));
       uint256 balanceV3 = IERC20(V3_A_TOKENS[i]).balanceOf(address(AaveV3Polygon.COLLECTOR));
 
       assertEq(IERC20(A_TOKENS[i]).balanceOf(address(proposal)), 0);

--- a/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/TreasuryManagementPolygonV2ToV3Migration.md
+++ b/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/TreasuryManagementPolygonV2ToV3Migration.md
@@ -6,7 +6,7 @@ discussions: "https://governance.aave.com/t/arfc-migrate-consolidate-polygon-tre
 
 ## Simple Summary
 
-This AIP will migrate all the DAOs assets held on Polygon v2 to Polygon v3.
+This AIP will migrate all the DAOs assets (except BAL, CRV & LINK) held on Polygon v2 to Polygon v3.
 
 ## Motivation
 
@@ -46,7 +46,7 @@ Deposit funds into Aave v3.
 - Implementation: [AaveV2Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.sol), [AaveV3Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV3Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.sol)
 - Tests: [AaveV2Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV2Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.t.sol), [AaveV3Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/AaveV3Polygon_TreasuryManagementPolygonV2ToV3Migration_20231208.t.sol)
 - [Snapshot](https://snapshot.org/#/aave.eth/proposal/0x1b816c12b6f547a1982198ffd0e36412390b05828b560c9edee4e8a6903c4882)
-- [Discussion](https://governance.aave.com/t/arfc-migrate-consolidate-polygon-treasury/12248)
+- [Discussion](https://governance.aave.com/t/arfc-migrate-consolidate-polygon-treasury/12248/4)
 
 ## Disclaimer
 

--- a/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/TreasuryManagementPolygonV2ToV3Migration.md
+++ b/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/TreasuryManagementPolygonV2ToV3Migration.md
@@ -6,7 +6,7 @@ discussions: "https://governance.aave.com/t/arfc-migrate-consolidate-polygon-tre
 
 ## Simple Summary
 
-This AIP will migrate all the DAOs assets (except BAL, CRV & LINK) held on Polygon v2 to Polygon v3.
+This AIP will migrate all the DAOs assets (except BAL & CRV) held on Polygon v2 to Polygon v3.
 
 ## Motivation
 

--- a/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/TreasuryManagementPolygonV2ToV3Migration_20231208.s.sol
+++ b/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/TreasuryManagementPolygonV2ToV3Migration_20231208.s.sol
@@ -38,7 +38,7 @@ contract CreateProposal is EthereumScript {
     // compose actions for validation
     IPayloadsControllerCore.ExecutionAction[]
       memory actionsPolygon = new IPayloadsControllerCore.ExecutionAction[](1);
-    actionsPolygon[0] = GovV3Helpers.buildAction(address(0));
+    actionsPolygon[0] = GovV3Helpers.buildAction(0x31B7F31dcCF8E8127a6f1619e6624A2a5Ef6713B);
     payloads[0] = GovV3Helpers.buildPolygonPayload(vm, actionsPolygon);
 
     // create proposal

--- a/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/config.json
+++ b/src/20231208_Multi_TreasuryManagementPolygonV2ToV3Migration/config.json
@@ -5,7 +5,7 @@
     "shortName": "TreasuryManagementPolygonV2ToV3Migration",
     "date": "20231208",
     "author": "TokenLogic",
-    "discussion": "https://governance.aave.com/t/arfc-migrate-consolidate-polygon-treasury/12248",
+    "discussion": "https://governance.aave.com/t/arfc-migrate-consolidate-polygon-treasury/12248/4",
     "snapshot": "https://snapshot.org/#/aave.eth/proposal/0x1b816c12b6f547a1982198ffd0e36412390b05828b560c9edee4e8a6903c4882"
   },
   "poolOptions": {


### PR DESCRIPTION
This AIP will migrate all the DAOs assets (except BAL, CRV & LINK) held on Polygon v2 to Polygon v3.