### PR TITLE
[Chaos Labs] Risk Parameter Updates - Increase USDe Debt Ceiling on V3 Ethereum

### DIFF
--- a/diffs/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801_before_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801_after.md
+++ b/diffs/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801_before_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801_after.md
@@ -1,0 +1,25 @@
+## Reserve changes
+
+### Reserves altered
+
+#### USDe ([0x4c9EDD5852cd905f086C759E8383e09bff1E68B3](https://etherscan.io/address/0x4c9EDD5852cd905f086C759E8383e09bff1E68B3))
+
+| description | value before | value after |
+| --- | --- | --- |
+| debtCeiling | 40,000,000 $ [4000000000] | 50,000,000 $ [5000000000] |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3": {
+      "debtCeiling": {
+        "from": 4000000000,
+        "to": 5000000000
+      }
+    }
+  }
+}
+```

--- a/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.sol
+++ b/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3PayloadEthereum} from 'aave-helpers/v3-config-engine/AaveV3PayloadEthereum.sol';
+import {EngineFlags} from 'aave-v3-periphery/contracts/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-periphery/contracts/v3-config-engine/IAaveV3ConfigEngine.sol';
+/**
+ * @title Risk Parameter Updates - Increase USDe Debt Ceiling on V3 Ethereum
+ * @author Chaos Labs
+ * - Snapshot: https://snapshot.org/#/aave.eth/proposal/0xea1012aaf1fe660148cfe6265cbadf23b19bb44af609caaa51ab8d7194259c28
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-usde-debt-ceiling-on-v3-ethereum-07-22-2024/18325
+ */
+contract AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801 is
+  AaveV3PayloadEthereum
+{
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumAssets.USDe_UNDERLYING,
+      ltv: EngineFlags.KEEP_CURRENT,
+      liqThreshold: EngineFlags.KEEP_CURRENT,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: 50_000_000,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+
+    return collateralUpdate;
+  }
+}

--- a/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.t.sol
+++ b/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801} from './AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.t.sol -vv
+ */
+contract AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801_Test is
+  ProtocolV3TestBase
+{
+  AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 20432284);
+    proposal = new AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    (ReserveConfig[] memory allConfigsBefore, ReserveConfig[] memory allConfigsAfter) = defaultTest(
+      'AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+
+    address[] memory assetsChanged = new address[](1);
+    assetsChanged[0] = AaveV3EthereumAssets.USDe_UNDERLYING;
+
+    _noReservesConfigsChangesApartFrom(allConfigsBefore, allConfigsAfter, assetsChanged);
+
+    ReserveConfig memory config = _findReserveConfig(
+      allConfigsAfter,
+      AaveV3EthereumAssets.USDe_UNDERLYING
+    );
+    assertEq(config.debtCeiling, 50_000_000_00);
+  }
+}

--- a/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum.md
+++ b/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum.md
@@ -1,0 +1,59 @@
+---
+title: "Risk Parameter Updates - Increase USDe Debt Ceiling on V3 Ethereum"
+author: "Chaos Labs"
+discussions: "https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-usde-debt-ceiling-on-v3-ethereum-07-22-2024/18325"
+snapshot: "https://snapshot.org/#/aave.eth/proposal/0xea1012aaf1fe660148cfe6265cbadf23b19bb44af609caaa51ab8d7194259c28"
+---
+
+## Simple Summary
+
+A proposal to increase USDe’s debt ceiling.
+
+## Motivation
+
+USDe has reached its debt ceiling following rapid deposits and borrows against these deposits on Ethereum.
+
+### Positions Analysis
+
+There is currently one major user utilizing USDe as collateral on V3 Ethereum.
+Account 0x8607a7d180de23645db594d90621d837749408d5 is borrowing $33.26 M in stables (USDC and USDT) against his $45.72 M in USDe. The user’s current health score is 1.03.
+
+While this market is heavily concentrated, simulated transactions indicate that this position could be liquidated efficiently.
+
+Borrows of USDe are more distributed and are against a variety of collateral.
+
+### Liquidity
+
+USDe liquidity has improved since the asset’s listing, with especially large growth on Curve, related to ENA token incentives provided in multiple pools.
+
+It is critical to note that on-chain liquidity — as well as the ratio of sUSDe to USDe, amongst other things — is being shaped by ongoing ENA token incentives. While there is still ongoing speculative activity, our recommendations remain cautious, given that dynamics could change rapidly following this period of speculative activity.
+
+We also note that USDe grew rapidly through May, reaching a high of over 3.6B, but has since declined to 3.4B. The reserve fund has also grown, though its size relative to USDe’s supply has fallen since the asset was listed, from 1.34% of total USDe supply to 1.33%.
+
+We also note that the reserve fund has not grown in accordance with our recommendations following a detailed assessment of Ethena’s mechanism, which called for the fund to maintain “sufficient capital to cover a 4.3% drawdown at all times.”
+
+### Recommendation
+
+The current debt ceiling for USDe on V3 Ethereum, set at $40 M, has reached 100% utilization.
+
+Given current market conditions, our Isolation Mode Methodology supports increasing the debt ceiling to $50 M.
+
+It is important to note that the majority of USDe debt positions are concentrated within just one user, accounting for over 83% of the total debt (see Positions Analysis above).
+While this concentration does not affect the current recommendation, it is something to continue monitoring and will be considered in future recommendations and cases of significant market changes.
+
+## Specification
+
+| Chain    | Asset | Parameter | Current Debt Ceiling | Recommended Debt Ceiling |
+| -------- | ----- | --------- | -------------------- | ------------------------ |
+| Ethereum | USDe  | LTV       | $40,000,000          | $50,000,000              |
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.t.sol)
+- [Snapshot](https://snapshot.org/#/aave.eth/proposal/0xea1012aaf1fe660148cfe6265cbadf23b19bb44af609caaa51ab8d7194259c28)
+- [Discussion](https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-usde-debt-ceiling-on-v3-ethereum-07-22-2024/18325)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.s.sol
+++ b/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801} from './AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801)
+        .creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum_20240801)
+        .creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum.md'
+      )
+    );
+  }
+}

--- a/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/config.ts
+++ b/src/20240801_AaveV3Ethereum_RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum/config.ts
@@ -1,0 +1,32 @@
+import {ConfigFile, VOTING_NETWORK} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title: 'Risk Parameter Updates - Increase USDe Debt Ceiling on V3 Ethereum',
+    shortName: 'RiskParameterUpdatesIncreaseUSDeDebtCeilingOnV3Ethereum',
+    date: '20240801',
+    author: 'Chaos Labs',
+    discussion:
+      'https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-usde-debt-ceiling-on-v3-ethereum-07-22-2024/18325',
+    snapshot:
+      'https://snapshot.org/#/aave.eth/proposal/0xea1012aaf1fe660148cfe6265cbadf23b19bb44af609caaa51ab8d7194259c28',
+    votingNetwork: VOTING_NETWORK.POLYGON,
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        COLLATERALS_UPDATE: [
+          {
+            asset: 'USDe',
+            ltv: '',
+            liqThreshold: '',
+            liqBonus: '',
+            debtCeiling: '50000000',
+            liqProtocolFee: '',
+          },
+        ],
+      },
+      cache: {blockNumber: 20432284},
+    },
+  },
+};


### PR DESCRIPTION
Snapshot:
https://snapshot.org/#/aave.eth/proposal/0xea1012aaf1fe660148cfe6265cbadf23b19bb44af609caaa51ab8d7194259c28

Discussion:
https://governance.aave.com/t/arfc-chaos-labs-risk-parameter-updates-increase-usde-debt-ceiling-on-v3-ethereum-07-22-2024/18325