### PR TITLE
feat: additional functionality for the generator

### DIFF
--- a/generator/cli.ts
+++ b/generator/cli.ts
@@ -48,6 +48,7 @@ program
     ).choices(Object.values(VOTING_NETWORK)),
   )
   .addOption(new Option('-c, --configFile <string>', 'path to config file'))
+  .addOption(new Option('-u, --update', 'when used with -c update block height'))
   .allowExcessArguments(false)
   .parse(process.argv);
 
@@ -138,6 +139,9 @@ if (options.configFile) {
         const module = v2
           ? FEATURE_MODULES_V2.find((m) => m.value === feature)!
           : FEATURE_MODULES_V3.find((m) => m.value === feature)!;
+        if (options.update) {
+          poolConfigs[pool]!.cache = await generateDeterministicPoolCache(pool);
+        }
         poolConfigs[pool]!.artifacts.push(
           module.build({
             options,


### PR DESCRIPTION
by passing the -u/--update flag when using the -c options the cached block height will get updated

Updating the block height for the test is actually something I end up doing manually from time to time
(e.g. after funding the collector for assets listing, when Aave get an update, etc)

And I actually lost a lot of time today because I forgot to do it. So in the off chance am not the only one am presenting this PR.

let me know if u have any feedback.