### PR TITLE
onboard gho on lido instance & migrate streams & cancel allowance

### DIFF
--- a/diffs/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104_before_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104_after.md
+++ b/diffs/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104_before_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104_after.md
@@ -1,0 +1,148 @@
+## Reserve changes
+
+### Reserves added
+
+#### GHO ([0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f](https://etherscan.io/address/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f))
+
+| description | value |
+| --- | --- |
+| decimals | 18 |
+| isActive | true |
+| isFrozen | false |
+| supplyCap | 11,000,000 GHO |
+| borrowCap | 10,000,000 GHO |
+| debtCeiling | 0 $ [0] |
+| isSiloed | false |
+| isFlashloanable | true |
+| oracle | [0xD110cac5d8682A3b045D5524a9903E031d70FCCd](https://etherscan.io/address/0xD110cac5d8682A3b045D5524a9903E031d70FCCd) |
+| oracleDecimals | 8 |
+| oracleLatestAnswer | 1 |
+| usageAsCollateralEnabled | true |
+| ltv | 75 % [7500] |
+| liquidationThreshold | 78 % [7800] |
+| liquidationBonus | 7.5 % |
+| liquidationProtocolFee | 10 % [1000] |
+| reserveFactor | 0.01 % [1] |
+| aToken | [0xc2015641564a5914A17CB9A92eC8d8feCfa8f2D0](https://etherscan.io/address/0xc2015641564a5914A17CB9A92eC8d8feCfa8f2D0) |
+| aTokenImpl | [0x7F8Fc14D462bdF93c681c1f2Fd615389bF969Fb2](https://etherscan.io/address/0x7F8Fc14D462bdF93c681c1f2Fd615389bF969Fb2) |
+| variableDebtToken | [0x2ABbAab3EF4e4A899d39e7EC996b5715E76b399a](https://etherscan.io/address/0x2ABbAab3EF4e4A899d39e7EC996b5715E76b399a) |
+| variableDebtTokenImpl | [0x3E59212c34588a63350142EFad594a20C88C2CEd](https://etherscan.io/address/0x3E59212c34588a63350142EFad594a20C88C2CEd) |
+| borrowingEnabled | true |
+| isBorrowableInIsolation | false |
+| interestRateStrategy | [0x8958b1C39269167527821f8c276Ef7504883f2fa](https://etherscan.io/address/0x8958b1C39269167527821f8c276Ef7504883f2fa) |
+| aTokenName | Aave Ethereum Lido GHO |
+| aTokenSymbol | aEthLidoGHO |
+| aTokenUnderlyingBalance | 6,760,840.6083 GHO [6760840608343987319695151] |
+| id | 5 |
+| isPaused | false |
+| variableDebtTokenName | Aave Ethereum Lido Variable Debt GHO |
+| variableDebtTokenSymbol | variableDebtEthLidoGHO |
+| virtualAccountingActive | true |
+| virtualBalance | 6,760,840.6083 GHO [6760840608343987319695151] |
+| optimalUsageRatio | 92 % |
+| maxVariableBorrowRate | 56.5 % |
+| baseVariableBorrowRate | 5.75 % |
+| variableRateSlope1 | 0.75 % |
+| variableRateSlope2 | 50 % |
+| interestRate | ![ir](https://dash.onaave.com/api/static?variableRateSlope1=7500000000000000000000000&variableRateSlope2=500000000000000000000000000&optimalUsageRatio=920000000000000000000000000&baseVariableBorrowRate=57500000000000000000000000&maxVariableBorrowRate=565000000000000000000000000) |
+
+
+## Emodes changed
+
+### EMode: ETH correlated(id: 1)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | ETH correlated | ETH correlated |
+| eMode.ltv (unchanged) | 93.5 % | 93.5 % |
+| eMode.liquidationThreshold (unchanged) | 95.5 % | 95.5 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | WETH | WETH |
+| eMode.collateralBitmap (unchanged) | wstETH, WETH | wstETH, WETH |
+
+
+### EMode: LRT Stablecoins main(id: 2)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | LRT Stablecoins main | LRT Stablecoins main |
+| eMode.ltv (unchanged) | 75 % | 75 % |
+| eMode.liquidationThreshold (unchanged) | 78 % | 78 % |
+| eMode.liquidationBonus (unchanged) | 7.5 % | 7.5 % |
+| eMode.borrowableBitmap (unchanged) | USDS | USDS |
+| eMode.collateralBitmap (unchanged) | ezETH | ezETH |
+
+
+### EMode: LRT wstETH main(id: 3)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | LRT wstETH main | LRT wstETH main |
+| eMode.ltv (unchanged) | 93 % | 93 % |
+| eMode.liquidationThreshold (unchanged) | 95 % | 95 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | wstETH | wstETH |
+| eMode.collateralBitmap (unchanged) | ezETH | ezETH |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": {
+      "from": null,
+      "to": {
+        "aToken": "0xc2015641564a5914A17CB9A92eC8d8feCfa8f2D0",
+        "aTokenImpl": "0x7F8Fc14D462bdF93c681c1f2Fd615389bF969Fb2",
+        "aTokenName": "Aave Ethereum Lido GHO",
+        "aTokenSymbol": "aEthLidoGHO",
+        "aTokenUnderlyingBalance": "6760840608343987319695151",
+        "borrowCap": 10000000,
+        "borrowingEnabled": true,
+        "debtCeiling": 0,
+        "decimals": 18,
+        "id": 5,
+        "interestRateStrategy": "0x8958b1C39269167527821f8c276Ef7504883f2fa",
+        "isActive": true,
+        "isBorrowableInIsolation": false,
+        "isFlashloanable": true,
+        "isFrozen": false,
+        "isPaused": false,
+        "isSiloed": false,
+        "liquidationBonus": 10750,
+        "liquidationProtocolFee": 1000,
+        "liquidationThreshold": 7800,
+        "ltv": 7500,
+        "oracle": "0xD110cac5d8682A3b045D5524a9903E031d70FCCd",
+        "oracleDecimals": 8,
+        "oracleLatestAnswer": "100000000",
+        "reserveFactor": 1,
+        "supplyCap": 11000000,
+        "symbol": "GHO",
+        "underlying": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+        "usageAsCollateralEnabled": true,
+        "variableDebtToken": "0x2ABbAab3EF4e4A899d39e7EC996b5715E76b399a",
+        "variableDebtTokenImpl": "0x3E59212c34588a63350142EFad594a20C88C2CEd",
+        "variableDebtTokenName": "Aave Ethereum Lido Variable Debt GHO",
+        "variableDebtTokenSymbol": "variableDebtEthLidoGHO",
+        "virtualAccountingActive": true,
+        "virtualBalance": "6760840608343987319695151"
+      }
+    }
+  },
+  "strategies": {
+    "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f": {
+      "from": null,
+      "to": {
+        "address": "0x8958b1C39269167527821f8c276Ef7504883f2fa",
+        "baseVariableBorrowRate": "57500000000000000000000000",
+        "maxVariableBorrowRate": "565000000000000000000000000",
+        "optimalUsageRatio": "920000000000000000000000000",
+        "variableRateSlope1": "7500000000000000000000000",
+        "variableRateSlope2": "500000000000000000000000000"
+      }
+    }
+  }
+}
+```

--- a/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.sol
+++ b/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {CollectorUtils} from 'aave-helpers/src/CollectorUtils.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3EthereumLido} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {AaveV3PayloadEthereumLido} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereumLido.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+import {SafeERC20} from 'solidity-utils/contracts/oz-common/SafeERC20.sol';
+
+/**
+ * @title Onboard GHO and Migrate Streams to Lido Instance
+ * @author karpatkey_TokenLogic
+ * - Snapshot: TBD
+ * - Discussion: https://governance.aave.com/t/arfc-onboard-gho-and-migrate-streams-to-lido-instance/19686
+ */
+contract AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104 is
+  AaveV3PayloadEthereumLido
+{
+  using SafeERC20 for IERC20;
+
+  uint256 public constant STREAM_0 = 100034;
+  uint256 public constant STREAM_1 = 100039;
+  uint256 public constant STREAM_2 = 100046;
+  uint256 public constant STREAM_3 = 100048;
+
+  address public constant AGD_MULTISIG = 0x89C51828427F70D77875C6747759fB17Ba10Ceb0;
+
+  uint256 public GHO_SEED_AMOUNT;
+
+  function _postExecute() internal override {
+    (address aTokenAddress, , ) = AaveV3EthereumLido
+      .AAVE_PROTOCOL_DATA_PROVIDER
+      .getReserveTokensAddresses(AaveV3EthereumAssets.GHO_UNDERLYING);
+
+    uint256[] memory streamIds = new uint256[](4);
+    streamIds[0] = STREAM_0;
+    streamIds[1] = STREAM_1;
+    streamIds[2] = STREAM_2;
+    streamIds[3] = STREAM_3;
+    // sends all remaining balances to receiver of stream
+    for (uint256 i = 0; i < 4; ) {
+      (
+        ,
+        address recipient,
+        uint256 deposit,
+        ,
+        uint256 startTime,
+        uint256 stopTime,
+        uint256 remainingBalance,
+        uint256 ratePerSecond
+      ) = AaveV3EthereumLido.COLLECTOR.getStream(streamIds[i]);
+
+      uint256 withdrawalBalance = AaveV3EthereumLido.COLLECTOR.balanceOf(streamIds[i], recipient);
+      AaveV3EthereumLido.COLLECTOR.cancelStream(streamIds[i]);
+
+      if (remainingBalance > withdrawalBalance) {
+        // create streams with a token
+        CollectorUtils.stream(
+          AaveV3EthereumLido.COLLECTOR,
+          CollectorUtils.CreateStreamInput({
+            underlying: aTokenAddress,
+            receiver: recipient,
+            amount: remainingBalance - withdrawalBalance,
+            start: startTime < block.timestamp ? block.timestamp : startTime,
+            duration: startTime < block.timestamp
+              ? stopTime - block.timestamp
+              : stopTime - startTime
+          })
+        );
+      }
+
+      unchecked {
+        ++i;
+      }
+    }
+
+    GHO_SEED_AMOUNT = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).balanceOf(
+      address(AaveV3EthereumLido.COLLECTOR)
+    );
+    AaveV3EthereumLido.COLLECTOR.transfer(
+      AaveV3EthereumAssets.GHO_UNDERLYING,
+      address(this),
+      GHO_SEED_AMOUNT
+    );
+    IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).forceApprove(
+      address(AaveV3EthereumLido.POOL),
+      GHO_SEED_AMOUNT
+    );
+    AaveV3EthereumLido.POOL.supply(
+      AaveV3EthereumAssets.GHO_UNDERLYING,
+      GHO_SEED_AMOUNT,
+      address(AaveV3EthereumLido.COLLECTOR),
+      0
+    );
+
+    if (
+      IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+        address(AaveV3EthereumLido.COLLECTOR),
+        AGD_MULTISIG
+      ) > 0
+    ) {
+      AaveV3EthereumLido.COLLECTOR.approve(AaveV3EthereumAssets.GHO_UNDERLYING, AGD_MULTISIG, 0);
+    }
+  }
+
+  function newListings() public pure override returns (IAaveV3ConfigEngine.Listing[] memory) {
+    IAaveV3ConfigEngine.Listing[] memory listings = new IAaveV3ConfigEngine.Listing[](1);
+
+    listings[0] = IAaveV3ConfigEngine.Listing({
+      asset: AaveV3EthereumAssets.GHO_UNDERLYING,
+      assetSymbol: 'GHO',
+      priceFeed: 0xD110cac5d8682A3b045D5524a9903E031d70FCCd,
+      enabledToBorrow: EngineFlags.ENABLED,
+      borrowableInIsolation: EngineFlags.DISABLED,
+      withSiloedBorrowing: EngineFlags.DISABLED,
+      flashloanable: EngineFlags.ENABLED,
+      ltv: 75_00,
+      liqThreshold: 78_00,
+      liqBonus: 7_50,
+      reserveFactor: 1,
+      supplyCap: 11_000_000,
+      borrowCap: 10_000_000,
+      debtCeiling: 0,
+      liqProtocolFee: 10_00,
+      rateStrategyParams: IAaveV3ConfigEngine.InterestRateInputData({
+        optimalUsageRatio: 92_00,
+        baseVariableBorrowRate: 5_75,
+        variableRateSlope1: 75,
+        variableRateSlope2: 50_00
+      })
+    });
+
+    return listings;
+  }
+}

--- a/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.t.sol
+++ b/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3EthereumLido} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104} from './AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.sol';
+
+/**
+ * @dev Test for AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.t.sol -vv
+ */
+contract AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104_Test is
+  ProtocolV3TestBase
+{
+  AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21118528);
+    proposal = new AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104',
+      AaveV3EthereumLido.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_migrateStream() public {
+    uint256[] memory streamIds = new uint256[](4);
+    address[] memory recipients = new address[](4);
+    uint256[] memory remainingBalances = new uint256[](4);
+    uint256[] memory beforeBalances = new uint256[](4);
+    uint256[] memory withdrawalBalances = new uint256[](5);
+    uint256[] memory startTimes = new uint256[](4);
+    uint256[] memory endTimes = new uint256[](4);
+
+    streamIds[0] = proposal.STREAM_0();
+    streamIds[1] = proposal.STREAM_1();
+    streamIds[2] = proposal.STREAM_2();
+    streamIds[3] = proposal.STREAM_3();
+
+    for (uint256 i = 0; i < 4; ++i) {
+      (, recipients[i], , , startTimes[i], endTimes[i], remainingBalances[i], ) = AaveV3EthereumLido
+        .COLLECTOR
+        .getStream(streamIds[i]);
+      withdrawalBalances[i] = AaveV3EthereumLido.COLLECTOR.balanceOf(streamIds[i], recipients[i]);
+      beforeBalances[i] = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).balanceOf(recipients[i]);
+    }
+
+    GovV3Helpers.executePayload(vm, address(proposal));
+
+    uint256 nextStreamId = AaveV3EthereumLido.COLLECTOR.getNextStreamId();
+
+    for (uint256 i = 0; i < 4; ++i) {
+      vm.expectRevert('stream does not exist');
+      AaveV3EthereumLido.COLLECTOR.getStream(streamIds[i]);
+
+      assertEq(
+        IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).balanceOf(recipients[i]),
+        beforeBalances[i] + withdrawalBalances[i]
+      );
+
+      (
+        ,
+        address newRecipient,
+        ,
+        ,
+        uint256 newStartTime,
+        uint256 newEndTime,
+        uint256 newRemainingBalance,
+
+      ) = AaveV3EthereumLido.COLLECTOR.getStream(nextStreamId - 4 + i);
+      assertEq(newRecipient, recipients[i]);
+      assertEq(newRemainingBalance, remainingBalances[i] - withdrawalBalances[i]);
+      if (block.timestamp < startTimes[i]) {
+        assertEq(startTimes[i], newStartTime);
+      } else {
+        assertEq(block.timestamp, newStartTime);
+      }
+      assertEq(endTimes[i], newEndTime);
+    }
+  }
+
+  function test_collectorHasGHOFunds() public {
+    GovV3Helpers.executePayload(vm, address(proposal));
+    (address aTokenAddress, , ) = AaveV3EthereumLido
+      .AAVE_PROTOCOL_DATA_PROVIDER
+      .getReserveTokensAddresses(AaveV3EthereumAssets.GHO_UNDERLYING);
+    assertGe(
+      IERC20(aTokenAddress).balanceOf(address(AaveV3EthereumLido.COLLECTOR)),
+      proposal.GHO_SEED_AMOUNT()
+    );
+  }
+
+  function test_agdAllowance() public {
+    uint256 allowance = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      address(AaveV3EthereumLido.COLLECTOR),
+      proposal.AGD_MULTISIG()
+    );
+    assertGt(allowance, 0);
+
+    GovV3Helpers.executePayload(vm, address(proposal));
+
+    allowance = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      address(AaveV3EthereumLido.COLLECTOR),
+      proposal.AGD_MULTISIG()
+    );
+    assertEq(allowance, 0);
+  }
+}

--- a/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance.md
+++ b/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance.md
@@ -1,0 +1,105 @@
+---
+title: "Onboard GHO and Migrate Streams to Lido Instance"
+author: "karpatkey_TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-onboard-gho-and-migrate-streams-to-lido-instance/19686"
+snapshot: "TBD"
+---
+
+## Simple Summary
+
+This publication proposes the following:
+
+- Onboarding GHO to the Lido instance of Aave v3;
+- Providing initial GHO liquidity from the Treasury; and,
+- Migrating Service Providers streams to GHO from Lido instance.
+
+## Motivation
+
+### Onboard GHO Lido Instance
+
+With the circulating supply nearing 180M and nearly 50M in DEX liquidity on Ethereum, this publication proposes adding GHO to the Lido instance of Aave v3.
+
+Adding GHO to the Lido instance of Aave v3 would provide the DAO with several opportunities:
+
+- Mint GHO through a Facilitator and deposit it into the Reserve to generate revenue;
+- Enable Aave DAO to earn yield on existing GHO holdings; and,
+- Establish a GHO reserve that provides an organic deposit yield.
+
+Each of these options offers clear advantages for the Aave DAO and GHO users. GHO is to be onboarded as a borrow-only asset, similar to the current configurations of USDC and USDS.
+
+### Deploy GHO from Treasury
+
+From observing the USDC reserve on the Lido instance, it is apparent that GHO would benefit from some initial liquidity. With passive GHO held in the Treasury, this publication proposes depositing available GHO into the new Reserve. With the GHO expected to earn a yield the DAO will benefit from a new revenue source.
+
+A separate proposal will recommend minting and depositing GHO into the new reserve via a new Facilitator on Ethereum to futher help bootstrap the reserve. The addition of sUSDe to the Lido instance is expected to provide strong demand for stablecoin debt.
+
+### Migrate Service Provider Streams
+
+With the GHO being deployed into Lido, several Aave DAO service provider streams are to be amended to draw GHO from Lido instance.
+
+- Chaos Labs;
+- Aave Labs;
+- LlamaRisk; and,
+- Aave Chan Initiative.
+
+When the AIP is submitted, new streams will be created to replace the streams being cancelled. With several streams are soon to expire during December, these streams are not migrated to Lido instance and sufficient GHO will remain in the treasury to facilitate payment to these teams.
+
+Within this publication, the Aave Grants DAO GHO Allowance is to be cancelled.
+
+## Specification
+
+The below details the parameter configuration of the GHO Reserve on the Lido instance of Aave v3.
+
+| Parameter                 |                                      Value |
+| ------------------------- | -----------------------------------------: |
+| Isolation Mode            |                                      false |
+| Borrowable                |                                    ENABLED |
+| Collateral Enabled        |                                       true |
+| Supply Cap (GHO)          |                                 11,000,000 |
+| Borrow Cap (GHO)          |                                 10,000,000 |
+| Debt Ceiling              |                                      USD 0 |
+| LTV                       |                                       75 % |
+| LT                        |                                       78 % |
+| Liquidation Bonus         |                                      7.5 % |
+| Liquidation Protocol Fee  |                                       10 % |
+| Reserve Factor            |                                     0.01 % |
+| Base Variable Borrow Rate |                                     5.75 % |
+| Variable Slope 1          |                                     0.75 % |
+| Variable Slope 2          |                                       50 % |
+| Uoptimal                  |                                       92 % |
+| Flashloanable             |                                    ENABLED |
+| Siloed Borrowing          |                                   DISABLED |
+| Borrowable in Isolation   |                                   DISABLED |
+| Oracle                    | 0xD110cac5d8682A3b045D5524a9903E031d70FCCd |
+
+The below table shows the GHO balance at time of writing for reference only:
+
+| Treasury Assert |                                                              Holding                                                               |
+| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------: |
+| GHO             | [7,295,678.65](https://etherscan.io/token/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f?a=0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c) |
+
+Note: The September funding update is to acquire GHO and transfer 5M GHO to Arbitrum to be deployed into the GHO reserve to earn yield.
+
+Sufficient GHO shall remain in the Treasury to support streams with a 2024 expiry date, with the balance to be deposited into the Lido instance of Aave v3. This will be confirmed and detailed in the comments just prior to submission of the AIP.
+
+The following Service Provider streams are to be migrated to using GHO from the Lido instance.
+
+| Service Provider     | StreamID |
+| :------------------- | :------: |
+| Aave Chan Initiative |  100034  |
+| Aave Labs            |  100039  |
+| Chaos Labs           |  100046  |
+| LlamaRisk            |  100048  |
+
+Cancel Aave Grants DAO GHO [Allowance](https://governance.aave.com/t/update-from-aave-grants-winding-down-agd-1-0-and-what-s-next/18707).
+
+## References
+
+- Implementation: [AaveV3EthereumLido](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.sol)
+- Tests: [AaveV3EthereumLido](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.t.sol)
+- [Snapshot](TBD)
+- [Discussion](https://governance.aave.com/t/arfc-onboard-gho-and-migrate-streams-to-lido-instance/19686)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance_20241104.s.sol
+++ b/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance_20241104.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104} from './AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance_20241104.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/OnboardGHOAndMigrateStreamsToLidoInstance_20241104.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance_20241104.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance_20241104).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/OnboardGHOAndMigrateStreamsToLidoInstance.md'
+      )
+    );
+  }
+}

--- a/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/config.ts
+++ b/src/20241104_AaveV3EthereumLido_OnboardGHOAndMigrateStreamsToLidoInstance/config.ts
@@ -1,0 +1,48 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3EthereumLido'],
+    title: 'Onboard GHO and Migrate Streams to Lido Instance',
+    shortName: 'OnboardGHOAndMigrateStreamsToLidoInstance',
+    date: '20241104',
+    author: 'karpatkey_TokenLogic',
+    discussion:
+      'https://governance.aave.com/t/arfc-onboard-gho-and-migrate-streams-to-lido-instance/19686',
+    snapshot: 'TBD',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {
+    AaveV3EthereumLido: {
+      configs: {
+        ASSET_LISTING: [
+          {
+            assetSymbol: 'GHO',
+            decimals: 18,
+            priceFeed: '0xD110cac5d8682A3b045D5524a9903E031d70FCCd',
+            ltv: '75',
+            liqThreshold: '78',
+            liqBonus: '7.5',
+            debtCeiling: '0',
+            liqProtocolFee: '10',
+            enabledToBorrow: 'ENABLED',
+            flashloanable: 'ENABLED',
+            borrowableInIsolation: 'DISABLED',
+            withSiloedBorrowing: 'DISABLED',
+            reserveFactor: '0.01',
+            supplyCap: '11000000',
+            borrowCap: '10000000',
+            rateStrategyParams: {
+              optimalUtilizationRate: '92',
+              baseVariableBorrowRate: '5.75',
+              variableRateSlope1: '0.75',
+              variableRateSlope2: '50',
+            },
+            asset: '0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f',
+            admin: '',
+          },
+        ],
+      },
+      cache: {blockNumber: 21118528},
+    },
+  },
+};


### PR DESCRIPTION
This PR proposes the following:

- Onboarding GHO to the Lido instance of Aave v3;
- Providing initial GHO liquidity from the Treasury; and,
- Migrating Service Providers streams to GHO from Lido instance.