### PR TITLE
✨ AAVE Buyback allocation

### DIFF
--- a/diffs/AaveV3Ethereum_AAVEBuybacksAllocation_20250403_before_AaveV3Ethereum_AAVEBuybacksAllocation_20250403_after.md
+++ b/diffs/AaveV3Ethereum_AAVEBuybacksAllocation_20250403_before_AaveV3Ethereum_AAVEBuybacksAllocation_20250403_after.md
@@ -1,0 +1,32 @@
+## Raw diff
+
+```json
+{
+  "raw": {
+    "0x23878914efe38d27c4d67ab83ed1b93a74d4086a": {
+      "label": "AaveV3Ethereum.ASSETS.USDT.A_TOKEN",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0xe81cbc5010bf701c96afcd9e85ab3c1ab37e3b123b04a49f76cc11c5ef1205b6": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000000000000000000000000000000003a352944000"
+        }
+      }
+    },
+    "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x6d5631d85c18100402670d785ac5189c387bc32d207d25d22fec73ef0b8a29a7": {
+          "previousValue": "0x0067eec086000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0067eec086000000000003000000000000000000000000000000000000000000"
+        },
+        "0x6d5631d85c18100402670d785ac5189c387bc32d207d25d22fec73ef0b8a29a8": {
+          "previousValue": "0x000000000000000000093a80000000000000681ce50700000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000681ce50700000000000067eec087"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation.md
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation.md
@@ -1,0 +1,23 @@
+---
+title: "AAVE Buybacks allocation"
+author: "ACI"
+discussions: "https://governance.aave.com/t/arfc-aavenomics-implementation-part-one/21248"
+snapshot: "https://snapshot.box/#/s:aave.eth/proposal/0xf0591fe8e54900da9929fe25c466c2b4a0fac6e8f7a3a000087797363847fb65"
+---
+
+## Simple Summary
+
+## Motivation
+
+## Specification
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.t.sol)
+- [Snapshot](https://snapshot.box/#/s:aave.eth/proposal/0xf0591fe8e54900da9929fe25c466c2b4a0fac6e8f7a3a000087797363847fb65)
+- [Discussion](https://governance.aave.com/t/arfc-aavenomics-implementation-part-one/21248)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation.md
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation.md
@@ -7,9 +7,30 @@ snapshot: "https://snapshot.box/#/s:aave.eth/proposal/0xf0591fe8e54900da9929fe25
 
 ## Simple Summary
 
+This proposal approves a specific allowance of **aEthUSDT** from the Aave Collector contract to the **Aave Finance Committee (AFC)**, enabling the committee to initiate AAVE buybacks as part of the Aavenomics implementation.
+
 ## Motivation
 
+As outlined in the [Aavenomics Part One proposal](https://governance.aave.com/t/arfc-aavenomics-implementation-part-one/21248), the Aave DAO is launching a structured AAVE Buy and Distribute program. The goal is to sustainably increase AAVE acquisition from the open market and distribute it to the Ecosystem Reserve.
+
+This initial proposal enables the AFC to begin executing the first phase of the buyback program by approving $4M in aEthUSDT, allowing for approximately one month of AAVE buybacks. While the full program targets up to $1M/week over six months, this limited approval serves as a first step. It also gives us time to finalize and deploy the updated Aave Swapper contract, which will be used for future buybacks.
+
+This allowance mechanism ensures:
+
+- Treasury operations remain secure, with no direct token transfer.
+- The AFC can operate within clearly defined, governance-approved budgets.
+- Buyback operations can begin without delay, supporting protocol alignment and tokenomics upgrades.
+
 ## Specification
+
+- **Asset**: aEthUSDT: 0x23878914EFE38d27C4D67Ab83ed1b93A74D4086a
+- **Amount**: 4M
+- **Spender**: [Aave Finance Committee (AFC)](https://etherscan.io/address/0x22740deBa78d5a0c24C58C740e3715ec29de1bFa): 0x22740deBa78d5a0c24C58C740e3715ec29de1bFa
+- **Method**: `approve()` aEthUSDT on the Aave Collector contract to the AFC address
+
+Once approved, the AFC will be able to pull USDT from the Collector contract to perform AAVE purchases on secondary markets or via market makers.
+
+This operation does **not** transfer any tokens at execution, and the allowance can be adjusted or revoked at any time through a new governance vote.
 
 ## References
 

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation_20250403.s.sol
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation_20250403.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_AAVEBuybacksAllocation_20250403} from './AaveV3Ethereum_AAVEBuybacksAllocation_20250403.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation_20250403.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/AAVEBuybacksAllocation_20250403.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_AAVEBuybacksAllocation_20250403).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation_20250403.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3Ethereum_AAVEBuybacksAllocation_20250403).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AAVEBuybacksAllocation.md'
+      )
+    );
+  }
+}

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.sol
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+
+/**
+ * @title AAVE Buybacks allocation
+ * @author ACI
+ * - Snapshot: https://snapshot.box/#/s:aave.eth/proposal/0xf0591fe8e54900da9929fe25c466c2b4a0fac6e8f7a3a000087797363847fb65
+ * - Discussion: https://governance.aave.com/t/arfc-aavenomics-implementation-part-one/21248
+ */
+contract AaveV3Ethereum_AAVEBuybacksAllocation_20250403 is IProposalGenericExecutor {
+  address public constant AFC = 0x22740deBa78d5a0c24C58C740e3715ec29de1bFa;
+
+  uint256 public constant USDT_AMOUNT = 4_000_000 * 10 ** 6; // 4M USDT
+
+  function execute() external {
+    // Approve USDT from Collector to AFC
+    AaveV3Ethereum.COLLECTOR.approve(IERC20(AaveV3EthereumAssets.USDT_A_TOKEN), AFC, USDT_AMOUNT);
+  }
+}

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.t.sol
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.t.sol
@@ -75,6 +75,7 @@ contract AaveV3Ethereum_AAVEBuybacksAllocation_20250403_Test is ProtocolV3TestBa
     uint256 diffBalanceAFC = balanceAFCAfter - balanceAFCBefore;
     uint256 diffBalanceCollector = balanceCollectorBefore - balanceCollectorAfter;
 
+    // -1 because of low decimal precision of USDT
     assertEq(diffBalanceAFC, proposal.USDT_AMOUNT() - 1);
     assertEq(diffBalanceCollector, proposal.USDT_AMOUNT());
   }

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.t.sol
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_AAVEBuybacksAllocation_20250403} from './AaveV3Ethereum_AAVEBuybacksAllocation_20250403.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_AAVEBuybacksAllocation_20250403
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/AaveV3Ethereum_AAVEBuybacksAllocation_20250403.t.sol -vv
+ */
+contract AaveV3Ethereum_AAVEBuybacksAllocation_20250403_Test is ProtocolV3TestBase {
+  AaveV3Ethereum_AAVEBuybacksAllocation_20250403 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22189779);
+    proposal = new AaveV3Ethereum_AAVEBuybacksAllocation_20250403();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Ethereum_AAVEBuybacksAllocation_20250403',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_allowance() external {
+    uint256 allowanceBefore = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(
+      address(AaveV3Ethereum.COLLECTOR),
+      proposal.AFC()
+    );
+
+    GovV3Helpers.executePayload(vm, address(proposal));
+
+    uint256 allowanceAfter = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(
+      address(AaveV3Ethereum.COLLECTOR),
+      proposal.AFC()
+    );
+
+    uint256 diffAllowance = allowanceAfter - allowanceBefore;
+    assertEq(diffAllowance, proposal.USDT_AMOUNT());
+  }
+
+  function test_claim() external {
+    uint256 balanceCollectorBefore = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+    uint256 balanceAFCBefore = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).balanceOf(proposal.AFC());
+
+    // execute approval
+    GovV3Helpers.executePayload(vm, address(proposal));
+
+    // execute transfer
+    vm.startPrank(proposal.AFC());
+    IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).transferFrom(
+      address(AaveV3Ethereum.COLLECTOR),
+      proposal.AFC(),
+      proposal.USDT_AMOUNT()
+    );
+    vm.stopPrank();
+
+    uint256 balanceCollectorAfter = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+    uint256 balanceAFCAfter = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).balanceOf(proposal.AFC());
+
+    uint256 diffBalanceAFC = balanceAFCAfter - balanceAFCBefore;
+    uint256 diffBalanceCollector = balanceCollectorBefore - balanceCollectorAfter;
+
+    assertEq(diffBalanceAFC, proposal.USDT_AMOUNT() - 1);
+    assertEq(diffBalanceCollector, proposal.USDT_AMOUNT());
+  }
+}

--- a/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/config.ts
+++ b/src/20250403_AaveV3Ethereum_AAVEBuybacksAllocation/config.ts
@@ -1,0 +1,15 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title: 'AAVE Buybacks allocation',
+    shortName: 'AAVEBuybacksAllocation',
+    date: '20250403',
+    author: 'ACI',
+    discussion: 'https://governance.aave.com/t/arfc-aavenomics-implementation-part-one/21248',
+    snapshot:
+      'https://snapshot.box/#/s:aave.eth/proposal/0xf0591fe8e54900da9929fe25c466c2b4a0fac6e8f7a3a000087797363847fb65',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {AaveV3Ethereum: {configs: {OTHERS: {}}, cache: {blockNumber: 22189779}}},
+};

--- a/verify.example.json
+++ b/verify.example.json
@@ -1,8 +1,8 @@
 {
   "transactions": [
     {
-      "hash": "0x9efe3dc77a9a407d17f98955e3a4d6e1516d0fe9f944c482dc994232b62e2aaf"
+      "hash": "0x47fc8c1fdbde4ce50c7eba7ac865ad6ce667fa17a4e033d019ba76c47438a5c7"
     }
   ],
-  "chain": 43114
+  "chain": 1088
 }

--- a/verify.example.json
+++ b/verify.example.json
@@ -1,8 +1,8 @@
 {
   "transactions": [
     {
-      "hash": "0x47fc8c1fdbde4ce50c7eba7ac865ad6ce667fa17a4e033d019ba76c47438a5c7"
+      "hash": "0x9efe3dc77a9a407d17f98955e3a4d6e1516d0fe9f944c482dc994232b62e2aaf"
     }
   ],
-  "chain": 1088
+  "chain": 43114
 }


### PR DESCRIPTION
## Recap

Approve 4M aEthUSDT from the Aave Ethereum Collector to the AFC

## Tests

Test passed but I had to lower by 1 unit the value received in aEThUSDT from the AFC.
Instead of having a balance diff of `4000000000000` we have a balance of `3999999999999`.
I didn't dig this so much but I supose this is an inaccuracy due to the only 6 decimals of USDT + the usage of index in the `balanceOf()` method of aToken.

I'll let me know about this.

Also maybe tests can be refactored, but I did something pretty straight forward.