### PR TITLE
eMode Unification

### DIFF
--- a/diffs/AaveV3Arbitrum_LRTAndWstETHUnification_20250430_before_AaveV3Arbitrum_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Arbitrum_LRTAndWstETHUnification_20250430_before_AaveV3Arbitrum_LRTAndWstETHUnification_20250430_after.md
@@ -1,0 +1,142 @@
+## Reserve changes
+
+### Reserves altered
+
+#### weETH ([0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe](https://arbiscan.io/address/0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 72.5 % [7250] | 75 % [7500] |
+| liquidationThreshold | 75 % [7500] | 77 % [7700] |
+
+
+## Emodes changed
+
+### EMode: Stablecoins(id: 1)
+
+
+
+### EMode: ETH correlated(id: 2)
+
+
+
+### EMode: ezETH wstETH(id: 3)
+
+
+
+### EMode: ezETH Stablecoins(id: 4)
+
+
+
+### EMode: rsETH wstETH(id: 5)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | rsETH wstETH | rsETH wstETH |
+| eMode.ltv | 92.5 % | 93 % |
+| eMode.liquidationThreshold | 94.5 % | 95 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | wstETH | wstETH |
+| eMode.collateralBitmap (unchanged) | rsETH | rsETH |
+
+
+### EMode: rsETH/Stablecoins(id: 6)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | rsETH/Stablecoins |
+| eMode.ltv | - | 72 % |
+| eMode.liquidationThreshold | - | 75 % |
+| eMode.liquidationBonus | - | 7.5 % |
+| eMode.borrowableBitmap | - | USDC, USD₮0 |
+| eMode.collateralBitmap | - | rsETH |
+
+
+## Raw diff
+
+```json
+{
+  "eModes": {
+    "5": {
+      "liquidationThreshold": {
+        "from": 9450,
+        "to": 9500
+      },
+      "ltv": {
+        "from": 9250,
+        "to": 9300
+      }
+    },
+    "6": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "36",
+        "collateralBitmap": "262144",
+        "eModeCategory": 6,
+        "label": "rsETH/Stablecoins",
+        "liquidationBonus": 10750,
+        "liquidationThreshold": 7500,
+        "ltv": 7200
+      }
+    }
+  },
+  "reserves": {
+    "0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe": {
+      "liquidationThreshold": {
+        "from": 7500,
+        "to": 7700
+      },
+      "ltv": {
+        "from": 7250,
+        "to": 7500
+      }
+    }
+  },
+  "raw": {
+    "0x794a61358d6845594f94dc1db02a252b5b4814ad": {
+      "label": "AaveV3Arbitrum.POOL",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d6": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000000000000000000000000004000029fe1d4c1c20"
+        },
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d7": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x72734554482f537461626c65636f696e73000000000000000000000000000022"
+        },
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d8": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000024"
+        },
+        "0x4f0da5bca7ea3ed2a5fd7fbf6d310bc05d68502cf438424218eeef530670c853": {
+          "previousValue": "0x100000000000000000000203e800001adb00000000011194851229fe1d4c1c52",
+          "newValue": "0x100000000000000000000203e800001adb00000000011194851229fe1e141d4c"
+        },
+        "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8257": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000040000277424ea2422",
+          "newValue": "0x00000000000000000000000000000000000000000000000400002774251c2454"
+        },
+        "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8258": {
+          "previousValue": "0x7273455448207773744554480000000000000000000000000000000000000018",
+          "newValue": "0x7273455448207773744554480000000000000000000000000000000000000018"
+        }
+      }
+    },
+    "0x89644ca1bb8064760312ae4f03ea41b05da3637c": {
+      "label": "GovernanceV3Arbitrum.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0xc201016ffcff91372d8b487e0ff78ba4e7738ee54ab48b285b35d26480999112": {
+          "previousValue": "0x0068114f54000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068114f54000000000003000000000000000000000000000000000000000000"
+        },
+        "0xc201016ffcff91372d8b487e0ff78ba4e7738ee54ab48b285b35d26480999113": {
+          "previousValue": "0x000000000000000000093a80000000000000683f73d500000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000683f73d500000000000068114f55"
+        }
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV3Arbitrum_LRTAndWstETHUnification_20250430_before_AaveV3Arbitrum_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Arbitrum_LRTAndWstETHUnification_20250430_before_AaveV3Arbitrum_LRTAndWstETHUnification_20250430_after.md
@@ -1,15 +1,3 @@
-## Reserve changes
-
-### Reserves altered
-
-#### weETH ([0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe](https://arbiscan.io/address/0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe))
-
-| description | value before | value after |
-| --- | --- | --- |
-| ltv | 72.5 % [7250] | 75 % [7500] |
-| liquidationThreshold | 75 % [7500] | 77 % [7700] |
-
-
 ## Emodes changed
 
 ### EMode: Stablecoins(id: 1)
@@ -80,18 +68,6 @@
       }
     }
   },
-  "reserves": {
-    "0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe": {
-      "liquidationThreshold": {
-        "from": 7500,
-        "to": 7700
-      },
-      "ltv": {
-        "from": 7250,
-        "to": 7500
-      }
-    }
-  },
   "raw": {
     "0x794a61358d6845594f94dc1db02a252b5b4814ad": {
       "label": "AaveV3Arbitrum.POOL",
@@ -108,10 +84,6 @@
         "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d8": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x0000000000000000000000000000000000000000000000000000000000000024"
-        },
-        "0x4f0da5bca7ea3ed2a5fd7fbf6d310bc05d68502cf438424218eeef530670c853": {
-          "previousValue": "0x100000000000000000000203e800001adb00000000011194851229fe1d4c1c52",
-          "newValue": "0x100000000000000000000203e800001adb00000000011194851229fe1e141d4c"
         },
         "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8257": {
           "previousValue": "0x0000000000000000000000000000000000000000000000040000277424ea2422",

--- a/diffs/AaveV3Base_LRTAndWstETHUnification_20250430_before_AaveV3Base_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Base_LRTAndWstETHUnification_20250430_before_AaveV3Base_LRTAndWstETHUnification_20250430_after.md
@@ -1,0 +1,250 @@
+## Reserve changes
+
+### Reserves altered
+
+#### weETH ([0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A](https://basescan.org/address/0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 72.5 % [7250] | 75 % [7500] |
+| liquidationThreshold | 75 % [7500] | 77 % [7700] |
+
+
+## Emodes changed
+
+### EMode: ETH correlated(id: 1)
+
+
+
+### EMode: ezETH wstETH(id: 2)
+
+
+
+### EMode: ezETH Stablecoins(id: 3)
+
+
+
+### EMode: LBTC_cbBTC(id: 4)
+
+
+
+### EMode: rsETH/wstETH(id: 5)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | rsETH/wstETH | rsETH/wstETH |
+| eMode.ltv | 92.5 % | 93 % |
+| eMode.liquidationThreshold | 94.5 % | 95 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | wstETH | wstETH |
+| eMode.collateralBitmap (unchanged) | wrsETH | wrsETH |
+
+
+### EMode: rsETH/USDC(id: 6)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | rsETH/USDC |
+| eMode.ltv | - | 72 % |
+| eMode.liquidationThreshold | - | 75 % |
+| eMode.liquidationBonus | - | 7.5 % |
+| eMode.borrowableBitmap | - | USDC |
+| eMode.collateralBitmap | - | wrsETH |
+
+
+### EMode: weETH/WETH(id: 7)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | weETH/WETH |
+| eMode.ltv | - | 93 % |
+| eMode.liquidationThreshold | - | 95 % |
+| eMode.liquidationBonus | - | 1.25 % |
+| eMode.borrowableBitmap | - | WETH |
+| eMode.collateralBitmap | - | weETH |
+
+
+### EMode: wstETH/WETH(id: 8)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | wstETH/WETH |
+| eMode.ltv | - | 93 % |
+| eMode.liquidationThreshold | - | 95 % |
+| eMode.liquidationBonus | - | 1 % |
+| eMode.borrowableBitmap | - | WETH |
+| eMode.collateralBitmap | - | wstETH |
+
+
+### EMode: cbETH/WETH(id: 9)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | cbETH/WETH |
+| eMode.ltv | - | 93 % |
+| eMode.liquidationThreshold | - | 95 % |
+| eMode.liquidationBonus | - | 2 % |
+| eMode.borrowableBitmap | - | WETH |
+| eMode.collateralBitmap | - | cbETH |
+
+
+## Raw diff
+
+```json
+{
+  "eModes": {
+    "5": {
+      "liquidationThreshold": {
+        "from": 9450,
+        "to": 9500
+      },
+      "ltv": {
+        "from": 9250,
+        "to": 9300
+      }
+    },
+    "6": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "16",
+        "collateralBitmap": "512",
+        "eModeCategory": 6,
+        "label": "rsETH/USDC",
+        "liquidationBonus": 10750,
+        "liquidationThreshold": 7500,
+        "ltv": 7200
+      }
+    },
+    "7": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "1",
+        "collateralBitmap": "32",
+        "eModeCategory": 7,
+        "label": "weETH/WETH",
+        "liquidationBonus": 10125,
+        "liquidationThreshold": 9500,
+        "ltv": 9300
+      }
+    },
+    "8": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "1",
+        "collateralBitmap": "8",
+        "eModeCategory": 8,
+        "label": "wstETH/WETH",
+        "liquidationBonus": 10100,
+        "liquidationThreshold": 9500,
+        "ltv": 9300
+      }
+    },
+    "9": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "1",
+        "collateralBitmap": "2",
+        "eModeCategory": 9,
+        "label": "cbETH/WETH",
+        "liquidationBonus": 10200,
+        "liquidationThreshold": 9500,
+        "ltv": 9300
+      }
+    }
+  },
+  "reserves": {
+    "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A": {
+      "liquidationThreshold": {
+        "from": 7500,
+        "to": 7700
+      },
+      "ltv": {
+        "from": 7250,
+        "to": 7500
+      }
+    }
+  },
+  "raw": {
+    "0x2dc219e716793fb4b21548c0f009ba3af753ab01": {
+      "label": "GovernanceV3Base.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0xd5310f85f4460a57771b0ba7c922e1273458411836157e863377c3ceba09ccc5": {
+          "previousValue": "0x0068114f54000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068114f54000000000003000000000000000000000000000000000000000000"
+        },
+        "0xd5310f85f4460a57771b0ba7c922e1273458411836157e863377c3ceba09ccc6": {
+          "previousValue": "0x000000000000000000093a80000000000000683f73d500000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000683f73d500000000000068114f55"
+        }
+      }
+    },
+    "0xa238dd80c259a72e81d7e4664a9801593f98d1c5": {
+      "label": "AaveV3Base.POOL",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d6": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000000000000000000000000000020029fe1d4c1c20"
+        },
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d7": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x72734554482f5553444300000000000000000000000000000000000000000014"
+        },
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d8": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000010"
+        },
+        "0x06511f122a6ecc4dc280e9f39df5119c2e43c998c438a2cdea36d46bbc885187": {
+          "previousValue": "0x100000000000000000000103e80000186a00000000011194851229fe1d4c1c52",
+          "newValue": "0x100000000000000000000103e80000186a00000000011194851229fe1e141d4c"
+        },
+        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40a": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000020278d251c2454"
+        },
+        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40b": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x77654554482f5745544800000000000000000000000000000000000000000014"
+        },
+        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40c": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        },
+        "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8257": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000200277424ea2422",
+          "newValue": "0x00000000000000000000000000000000000000000000000002002774251c2454"
+        },
+        "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8258": {
+          "previousValue": "0x72734554482f7773744554480000000000000000000000000000000000000018",
+          "newValue": "0x72734554482f7773744554480000000000000000000000000000000000000018"
+        },
+        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481917": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000000000000000000000000000000082774251c2454"
+        },
+        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481918": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
+        },
+        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481919": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        },
+        "0xe6576186fab02514991562c0b55059c5b708dacefbb0b209be6f33d8dcdcb49b": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000000000000000000000000000000227d8251c2454"
+        },
+        "0xe6576186fab02514991562c0b55059c5b708dacefbb0b209be6f33d8dcdcb49c": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x63624554482f5745544800000000000000000000000000000000000000000014"
+        },
+        "0xe6576186fab02514991562c0b55059c5b708dacefbb0b209be6f33d8dcdcb49d": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        }
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV3Base_LRTAndWstETHUnification_20250430_before_AaveV3Base_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Base_LRTAndWstETHUnification_20250430_before_AaveV3Base_LRTAndWstETHUnification_20250430_after.md
@@ -1,27 +1,7 @@
-## Reserve changes
-
-### Reserves altered
-
-#### weETH ([0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A](https://basescan.org/address/0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A))
-
-| description | value before | value after |
-| --- | --- | --- |
-| ltv | 72.5 % [7250] | 75 % [7500] |
-| liquidationThreshold | 75 % [7500] | 77 % [7700] |
-
-
 ## Emodes changed
 
 ### EMode: ETH correlated(id: 1)
 
-| description | value before | value after |
-| --- | --- | --- |
-| eMode.label (unchanged) | ETH correlated | ETH correlated |
-| eMode.ltv (unchanged) | 90 % | 90 % |
-| eMode.liquidationThreshold (unchanged) | 93 % | 93 % |
-| eMode.liquidationBonus (unchanged) | 2 % | 2 % |
-| eMode.borrowableBitmap | WETH, cbETH, wstETH, weETH | cbETH, wstETH, weETH |
-| eMode.collateralBitmap | WETH, cbETH, wstETH, weETH | cbETH, wstETH, weETH |
 
 
 ### EMode: ezETH wstETH(id: 2)
@@ -101,16 +81,6 @@
 ```json
 {
   "eModes": {
-    "1": {
-      "borrowableBitmap": {
-        "from": "43",
-        "to": "42"
-      },
-      "collateralBitmap": {
-        "from": "43",
-        "to": "42"
-      }
-    },
     "5": {
       "liquidationThreshold": {
         "from": 9450,
@@ -170,18 +140,6 @@
       }
     }
   },
-  "reserves": {
-    "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A": {
-      "liquidationThreshold": {
-        "from": 7500,
-        "to": 7700
-      },
-      "ltv": {
-        "from": 7250,
-        "to": 7500
-      }
-    }
-  },
   "raw": {
     "0x2dc219e716793fb4b21548c0f009ba3af753ab01": {
       "label": "GovernanceV3Base.PAYLOADS_CONTROLLER",
@@ -213,10 +171,6 @@
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x0000000000000000000000000000000000000000000000000000000000000010"
         },
-        "0x06511f122a6ecc4dc280e9f39df5119c2e43c998c438a2cdea36d46bbc885187": {
-          "previousValue": "0x100000000000000000000103e80000186a00000000011194851229fe1d4c1c52",
-          "newValue": "0x100000000000000000000103e80000186a00000000011194851229fe1e141d4c"
-        },
         "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40a": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x0000000000000000000000000000000000000000000000000020278d251c2454"
@@ -236,14 +190,6 @@
         "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8258": {
           "previousValue": "0x72734554482f7773744554480000000000000000000000000000000000000018",
           "newValue": "0x72734554482f7773744554480000000000000000000000000000000000000018"
-        },
-        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb0": {
-          "previousValue": "0x000000000000000000000000000000000000000000000000002b27d824542328",
-          "newValue": "0x000000000000000000000000000000000000000000000000002a27d824542328"
-        },
-        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb2": {
-          "previousValue": "0x000000000000000000000000000000000000000000000000000000000000002b",
-          "newValue": "0x000000000000000000000000000000000000000000000000000000000000002a"
         },
         "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481917": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/diffs/AaveV3Base_LRTAndWstETHUnification_20250430_before_AaveV3Base_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Base_LRTAndWstETHUnification_20250430_before_AaveV3Base_LRTAndWstETHUnification_20250430_after.md
@@ -14,6 +14,14 @@
 
 ### EMode: ETH correlated(id: 1)
 
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | ETH correlated | ETH correlated |
+| eMode.ltv (unchanged) | 90 % | 90 % |
+| eMode.liquidationThreshold (unchanged) | 93 % | 93 % |
+| eMode.liquidationBonus (unchanged) | 2 % | 2 % |
+| eMode.borrowableBitmap | WETH, cbETH, wstETH, weETH | cbETH, wstETH, weETH |
+| eMode.collateralBitmap | WETH, cbETH, wstETH, weETH | cbETH, wstETH, weETH |
 
 
 ### EMode: ezETH wstETH(id: 2)
@@ -93,6 +101,16 @@
 ```json
 {
   "eModes": {
+    "1": {
+      "borrowableBitmap": {
+        "from": "43",
+        "to": "42"
+      },
+      "collateralBitmap": {
+        "from": "43",
+        "to": "42"
+      }
+    },
     "5": {
       "liquidationThreshold": {
         "from": 9450,
@@ -218,6 +236,14 @@
         "0x50039cf134a124858bd88bbc9225ec3c537b89a0e9237ce39fe1813e6edf8258": {
           "previousValue": "0x72734554482f7773744554480000000000000000000000000000000000000018",
           "newValue": "0x72734554482f7773744554480000000000000000000000000000000000000018"
+        },
+        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb0": {
+          "previousValue": "0x000000000000000000000000000000000000000000000000002b27d824542328",
+          "newValue": "0x000000000000000000000000000000000000000000000000002a27d824542328"
+        },
+        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb2": {
+          "previousValue": "0x000000000000000000000000000000000000000000000000000000000000002b",
+          "newValue": "0x000000000000000000000000000000000000000000000000000000000000002a"
         },
         "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481917": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
@@ -1,0 +1,168 @@
+## Reserve changes
+
+### Reserve altered
+
+#### wstETH ([0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 80 % [8000] | 82 % [8200] |
+| liquidationThreshold | 81 % [8100] | 83 % [8300] |
+
+
+#### WETH ([0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2](https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 82 % [8200] | 84 % [8400] |
+| liquidationThreshold | 83 % [8300] | 85 % [8500] |
+
+
+## Emodes changed
+
+### EMode: wstETH/WETH(id: 1)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | ETH correlated | wstETH/WETH |
+| eMode.ltv | 93.5 % | 95 % |
+| eMode.liquidationThreshold | 95.5 % | 96.5 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | WETH | WETH |
+| eMode.collateralBitmap (unchanged) | wstETH | wstETH |
+
+
+### EMode: LRT Stablecoins main(id: 2)
+
+
+
+### EMode: LRT wstETH main(id: 3)
+
+
+
+### EMode: sUSDe Stablecoins(id: 4)
+
+
+
+### EMode: rsETH LST main(id: 5)
+
+
+
+### EMode: rsETH/Stablecoins(id: 6)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | rsETH/Stablecoins |
+| eMode.ltv | - | 72 % |
+| eMode.liquidationThreshold | - | 75 % |
+| eMode.liquidationBonus | - | 7.5 % |
+| eMode.borrowableBitmap | - | USDS, USDC, GHO |
+| eMode.collateralBitmap | - | rsETH |
+
+
+## Raw diff
+
+```json
+{
+  "eModes": {
+    "1": {
+      "label": {
+        "from": "ETH correlated",
+        "to": "wstETH/WETH"
+      },
+      "liquidationThreshold": {
+        "from": 9550,
+        "to": 9650
+      },
+      "ltv": {
+        "from": 9350,
+        "to": 9500
+      }
+    },
+    "6": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "76",
+        "collateralBitmap": "128",
+        "eModeCategory": 6,
+        "label": "rsETH/Stablecoins",
+        "liquidationBonus": 10750,
+        "liquidationThreshold": 7500,
+        "ltv": 7200
+      }
+    }
+  },
+  "reserves": {
+    "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": {
+      "liquidationThreshold": {
+        "from": 8100,
+        "to": 8300
+      },
+      "ltv": {
+        "from": 8000,
+        "to": 8200
+      }
+    },
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+      "liquidationThreshold": {
+        "from": 8300,
+        "to": 8500
+      },
+      "ltv": {
+        "from": 8200,
+        "to": 8400
+      }
+    }
+  },
+  "raw": {
+    "0x4e033931ad43597d96d6bcc25c280717730b58b1": {
+      "label": "AaveV3EthereumLido.POOL",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d6": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000000000000000000000000000008029fe1d4c1c20"
+        },
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d7": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x72734554482f537461626c65636f696e73000000000000000000000000000022"
+        },
+        "0x01290583d43e205f46f8d824d1236df318521e471f570a5b36fa1844856e40d8": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000000000000000000000000000000000000000004c"
+        },
+        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb0": {
+          "previousValue": "0x00000000000000000000000000000000000000000000000000012774254e2486",
+          "newValue": "0x0000000000000000000000000000000000000000000000000001277425b2251c"
+        },
+        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb1": {
+          "previousValue": "0x45544820636f7272656c6174656400000000000000000000000000000000001c",
+          "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
+        },
+        "0xc9d7ec48cd0d839522455f78914adfeda8686316bb6819e0888e4bcd349e01b2": {
+          "previousValue": "0x100000000000000000000103e800009eb100000445c001f4851229681fa41f40",
+          "newValue": "0x100000000000000000000103e800009eb100000445c001f485122968206c2008"
+        },
+        "0xf81d8d79f42adb4c73cc3aa0c78e25d3343882d0313c0b80ece3d3a103ef1ebf": {
+          "previousValue": "0x100000000000000000000103e80000dbba00000c5c1003e885122904206c2008",
+          "newValue": "0x100000000000000000000103e80000dbba00000c5c1003e885122904213420d0"
+        }
+      }
+    },
+    "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x57c0d0964870c24387de1cb96a1c0d1e031544394130654a48994b8a35b62a81": {
+          "previousValue": "0x0068114f4a000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068114f4a000000000003000000000000000000000000000000000000000000"
+        },
+        "0x57c0d0964870c24387de1cb96a1c0d1e031544394130654a48994b8a35b62a82": {
+          "previousValue": "0x000000000000000000093a80000000000000683f73cb00000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000683f73cb00000000000068114f4b"
+        }
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
@@ -1,34 +1,14 @@
-## Reserve changes
-
-### Reserve altered
-
-#### wstETH ([0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0))
-
-| description | value before | value after |
-| --- | --- | --- |
-| ltv | 80 % [8000] | 82 % [8200] |
-| liquidationThreshold | 81 % [8100] | 83 % [8300] |
-
-
-#### WETH ([0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2](https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2))
-
-| description | value before | value after |
-| --- | --- | --- |
-| ltv | 82 % [8200] | 84 % [8400] |
-| liquidationThreshold | 83 % [8300] | 85 % [8500] |
-
-
 ## Emodes changed
 
-### EMode: ETH correlated(id: 1)
+### EMode: wstETH/WETH(id: 1)
 
 | description | value before | value after |
 | --- | --- | --- |
-| eMode.label (unchanged) | ETH correlated | ETH correlated |
-| eMode.ltv (unchanged) | 93.5 % | 93.5 % |
-| eMode.liquidationThreshold (unchanged) | 95.5 % | 95.5 % |
+| eMode.label | ETH correlated | wstETH/WETH |
+| eMode.ltv | 93.5 % | 95 % |
+| eMode.liquidationThreshold | 95.5 % | 96.5 % |
 | eMode.liquidationBonus (unchanged) | 1 % | 1 % |
-| eMode.borrowableBitmap | WETH |  |
+| eMode.borrowableBitmap (unchanged) | WETH | WETH |
 | eMode.collateralBitmap (unchanged) | wstETH | wstETH |
 
 
@@ -60,27 +40,23 @@
 | eMode.collateralBitmap | - | rsETH |
 
 
-### EMode: wstETH/WETH(id: 7)
-
-| description | value before | value after |
-| --- | --- | --- |
-| eMode.label | - | wstETH/WETH |
-| eMode.ltv | - | 95 % |
-| eMode.liquidationThreshold | - | 96.5 % |
-| eMode.liquidationBonus | - | 1 % |
-| eMode.borrowableBitmap | - | WETH |
-| eMode.collateralBitmap | - | wstETH |
-
-
 ## Raw diff
 
 ```json
 {
   "eModes": {
     "1": {
-      "borrowableBitmap": {
-        "from": "2",
-        "to": "0"
+      "label": {
+        "from": "ETH correlated",
+        "to": "wstETH/WETH"
+      },
+      "liquidationThreshold": {
+        "from": 9550,
+        "to": 9650
+      },
+      "ltv": {
+        "from": 9350,
+        "to": 9500
       }
     },
     "6": {
@@ -93,40 +69,6 @@
         "liquidationBonus": 10750,
         "liquidationThreshold": 7500,
         "ltv": 7200
-      }
-    },
-    "7": {
-      "from": null,
-      "to": {
-        "borrowableBitmap": "2",
-        "collateralBitmap": "1",
-        "eModeCategory": 7,
-        "label": "wstETH/WETH",
-        "liquidationBonus": 10100,
-        "liquidationThreshold": 9650,
-        "ltv": 9500
-      }
-    }
-  },
-  "reserves": {
-    "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": {
-      "liquidationThreshold": {
-        "from": 8100,
-        "to": 8300
-      },
-      "ltv": {
-        "from": 8000,
-        "to": 8200
-      }
-    },
-    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
-      "liquidationThreshold": {
-        "from": 8300,
-        "to": 8500
-      },
-      "ltv": {
-        "from": 8200,
-        "to": 8400
       }
     }
   },
@@ -147,33 +89,13 @@
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x000000000000000000000000000000000000000000000000000000000000004c"
         },
-        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40a": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "newValue": "0x0000000000000000000000000000000000000000000000000001277425b2251c"
-        },
-        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40b": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
-        },
-        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40c": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000002"
-        },
         "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb0": {
           "previousValue": "0x00000000000000000000000000000000000000000000000000012774254e2486",
-          "newValue": "0x00000000000000000000000000000000000000000000000000012774254e2486"
+          "newValue": "0x0000000000000000000000000000000000000000000000000001277425b2251c"
         },
-        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb2": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000002",
-          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000000"
-        },
-        "0xc9d7ec48cd0d839522455f78914adfeda8686316bb6819e0888e4bcd349e01b2": {
-          "previousValue": "0x100000000000000000000103e800009eb100000445c001f4851229681fa41f40",
-          "newValue": "0x100000000000000000000103e800009eb100000445c001f485122968206c2008"
-        },
-        "0xf81d8d79f42adb4c73cc3aa0c78e25d3343882d0313c0b80ece3d3a103ef1ebf": {
-          "previousValue": "0x100000000000000000000103e80000dbba00000c5c1003e885122904206c2008",
-          "newValue": "0x100000000000000000000103e80000dbba00000c5c1003e885122904213420d0"
+        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb1": {
+          "previousValue": "0x45544820636f7272656c6174656400000000000000000000000000000000001c",
+          "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
         }
       }
     },

--- a/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
@@ -20,15 +20,15 @@
 
 ## Emodes changed
 
-### EMode: wstETH/WETH(id: 1)
+### EMode: ETH correlated(id: 1)
 
 | description | value before | value after |
 | --- | --- | --- |
-| eMode.label | ETH correlated | wstETH/WETH |
-| eMode.ltv | 93.5 % | 95 % |
-| eMode.liquidationThreshold | 95.5 % | 96.5 % |
+| eMode.label (unchanged) | ETH correlated | ETH correlated |
+| eMode.ltv (unchanged) | 93.5 % | 93.5 % |
+| eMode.liquidationThreshold (unchanged) | 95.5 % | 95.5 % |
 | eMode.liquidationBonus (unchanged) | 1 % | 1 % |
-| eMode.borrowableBitmap (unchanged) | WETH | WETH |
+| eMode.borrowableBitmap | WETH |  |
 | eMode.collateralBitmap (unchanged) | wstETH | wstETH |
 
 
@@ -60,23 +60,27 @@
 | eMode.collateralBitmap | - | rsETH |
 
 
+### EMode: wstETH/WETH(id: 7)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | wstETH/WETH |
+| eMode.ltv | - | 95 % |
+| eMode.liquidationThreshold | - | 96.5 % |
+| eMode.liquidationBonus | - | 1 % |
+| eMode.borrowableBitmap | - |  |
+| eMode.collateralBitmap | - |  |
+
+
 ## Raw diff
 
 ```json
 {
   "eModes": {
     "1": {
-      "label": {
-        "from": "ETH correlated",
-        "to": "wstETH/WETH"
-      },
-      "liquidationThreshold": {
-        "from": 9550,
-        "to": 9650
-      },
-      "ltv": {
-        "from": 9350,
-        "to": 9500
+      "borrowableBitmap": {
+        "from": "2",
+        "to": "0"
       }
     },
     "6": {
@@ -89,6 +93,18 @@
         "liquidationBonus": 10750,
         "liquidationThreshold": 7500,
         "ltv": 7200
+      }
+    },
+    "7": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "0",
+        "collateralBitmap": "0",
+        "eModeCategory": 7,
+        "label": "wstETH/WETH",
+        "liquidationBonus": 10100,
+        "liquidationThreshold": 9650,
+        "ltv": 9500
       }
     }
   },
@@ -131,13 +147,21 @@
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x000000000000000000000000000000000000000000000000000000000000004c"
         },
+        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40a": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000277425b2251c"
+        },
+        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40b": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
+        },
         "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb0": {
           "previousValue": "0x00000000000000000000000000000000000000000000000000012774254e2486",
-          "newValue": "0x0000000000000000000000000000000000000000000000000001277425b2251c"
+          "newValue": "0x00000000000000000000000000000000000000000000000000012774254e2486"
         },
-        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb1": {
-          "previousValue": "0x45544820636f7272656c6174656400000000000000000000000000000000001c",
-          "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
+        "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb2": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000000"
         },
         "0xc9d7ec48cd0d839522455f78914adfeda8686316bb6819e0888e4bcd349e01b2": {
           "previousValue": "0x100000000000000000000103e800009eb100000445c001f4851229681fa41f40",

--- a/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3EthereumLido_LRTAndWstETHUnification_20250430_before_AaveV3EthereumLido_LRTAndWstETHUnification_20250430_after.md
@@ -68,8 +68,8 @@
 | eMode.ltv | - | 95 % |
 | eMode.liquidationThreshold | - | 96.5 % |
 | eMode.liquidationBonus | - | 1 % |
-| eMode.borrowableBitmap | - |  |
-| eMode.collateralBitmap | - |  |
+| eMode.borrowableBitmap | - | WETH |
+| eMode.collateralBitmap | - | wstETH |
 
 
 ## Raw diff
@@ -98,8 +98,8 @@
     "7": {
       "from": null,
       "to": {
-        "borrowableBitmap": "0",
-        "collateralBitmap": "0",
+        "borrowableBitmap": "2",
+        "collateralBitmap": "1",
         "eModeCategory": 7,
         "label": "wstETH/WETH",
         "liquidationBonus": 10100,
@@ -149,11 +149,15 @@
         },
         "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40a": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "newValue": "0x0000000000000000000000000000000000000000000000000000277425b2251c"
+          "newValue": "0x0000000000000000000000000000000000000000000000000001277425b2251c"
         },
         "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40b": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x7773744554482f57455448000000000000000000000000000000000000000016"
+        },
+        "0x1e4061ed12ce1f4439fe6c7922bd1dce45af754358ce2f94214f93749947e40c": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000002"
         },
         "0x8e0cc0f1f0504b4cb44a23b328568106915b169e79003737a7b094503cdbeeb0": {
           "previousValue": "0x00000000000000000000000000000000000000000000000000012774254e2486",

--- a/diffs/AaveV3Ethereum_LRTAndWstETHUnification_20250430_before_AaveV3Ethereum_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Ethereum_LRTAndWstETHUnification_20250430_before_AaveV3Ethereum_LRTAndWstETHUnification_20250430_after.md
@@ -28,7 +28,15 @@
 
 
 
-### EMode: rsETH/wstETH(id: 8)
+### EMode: PT-sUSDe Stablecoins Jul 2025(id: 8)
+
+
+
+### EMode: PT-eUSDe Stablecoins May 2025(id: 9)
+
+
+
+### EMode: rsETH/wstETH(id: 10)
 
 | description | value before | value after |
 | --- | --- | --- |
@@ -45,12 +53,12 @@
 ```json
 {
   "eModes": {
-    "8": {
+    "10": {
       "from": null,
       "to": {
         "borrowableBitmap": "2",
         "collateralBitmap": "68719476736",
-        "eModeCategory": 8,
+        "eModeCategory": 10,
         "label": "rsETH/wstETH",
         "liquidationBonus": 10100,
         "liquidationThreshold": 9500,
@@ -63,15 +71,15 @@
       "label": "AaveV3Ethereum.POOL",
       "balanceDiff": null,
       "stateDiff": {
-        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481917": {
+        "0xb6395f9c432dd8cece69c29d0bafa901e98160153dacb5e1d5fb45e8d47ba1d6": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x00000000000000000000000000000000000000000010000000002774251c2454"
         },
-        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481918": {
+        "0xb6395f9c432dd8cece69c29d0bafa901e98160153dacb5e1d5fb45e8d47ba1d7": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x72734554482f7773744554480000000000000000000000000000000000000018"
         },
-        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481919": {
+        "0xb6395f9c432dd8cece69c29d0bafa901e98160153dacb5e1d5fb45e8d47ba1d8": {
           "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "newValue": "0x0000000000000000000000000000000000000000000000000000000000000002"
         }
@@ -81,13 +89,13 @@
       "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
       "balanceDiff": null,
       "stateDiff": {
-        "0x57c0d0964870c24387de1cb96a1c0d1e031544394130654a48994b8a35b62a81": {
-          "previousValue": "0x0068114f4a000000000002000000000000000000000000000000000000000000",
-          "newValue": "0x0068114f4a000000000003000000000000000000000000000000000000000000"
+        "0x64c02d3179204055dad2cccfeeb0b65da6899a4e845aea52a7a0af7337c9130f": {
+          "previousValue": "0x00681e138e000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x00681e138e000000000003000000000000000000000000000000000000000000"
         },
-        "0x57c0d0964870c24387de1cb96a1c0d1e031544394130654a48994b8a35b62a82": {
-          "previousValue": "0x000000000000000000093a80000000000000683f73cb00000000000000000000",
-          "newValue": "0x000000000000000000093a80000000000000683f73cb00000000000068114f4b"
+        "0x64c02d3179204055dad2cccfeeb0b65da6899a4e845aea52a7a0af7337c91310": {
+          "previousValue": "0x000000000000000000093a80000000000000684c380f00000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000684c380f000000000000681e138f"
         }
       }
     }

--- a/diffs/AaveV3Ethereum_LRTAndWstETHUnification_20250430_before_AaveV3Ethereum_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Ethereum_LRTAndWstETHUnification_20250430_before_AaveV3Ethereum_LRTAndWstETHUnification_20250430_after.md
@@ -10,6 +10,14 @@
 
 ### EMode: rsETH LST main(id: 3)
 
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | rsETH LST main | rsETH LST main |
+| eMode.ltv | 92.5 % | 93 % |
+| eMode.liquidationThreshold | 94.5 % | 95 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | wstETH, ETHx | wstETH, ETHx |
+| eMode.collateralBitmap (unchanged) | rsETH | rsETH |
 
 
 ### EMode: LBTC_WBTC(id: 4)
@@ -36,33 +44,19 @@
 
 
 
-### EMode: rsETH/wstETH(id: 10)
-
-| description | value before | value after |
-| --- | --- | --- |
-| eMode.label | - | rsETH/wstETH |
-| eMode.ltv | - | 93 % |
-| eMode.liquidationThreshold | - | 95 % |
-| eMode.liquidationBonus | - | 1 % |
-| eMode.borrowableBitmap | - | wstETH |
-| eMode.collateralBitmap | - | rsETH |
-
-
 ## Raw diff
 
 ```json
 {
   "eModes": {
-    "10": {
-      "from": null,
-      "to": {
-        "borrowableBitmap": "2",
-        "collateralBitmap": "68719476736",
-        "eModeCategory": 10,
-        "label": "rsETH/wstETH",
-        "liquidationBonus": 10100,
-        "liquidationThreshold": 9500,
-        "ltv": 9300
+    "3": {
+      "liquidationThreshold": {
+        "from": 9450,
+        "to": 9500
+      },
+      "ltv": {
+        "from": 9250,
+        "to": 9300
       }
     }
   },
@@ -71,17 +65,13 @@
       "label": "AaveV3Ethereum.POOL",
       "balanceDiff": null,
       "stateDiff": {
-        "0xb6395f9c432dd8cece69c29d0bafa901e98160153dacb5e1d5fb45e8d47ba1d6": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x81d0999fde243adcc41b7fa1be5cea14f789e3a6065b815ac58f4bc0838c3155": {
+          "previousValue": "0x0000000000000000000000000000000000000000001000000000277424ea2422",
           "newValue": "0x00000000000000000000000000000000000000000010000000002774251c2454"
         },
-        "0xb6395f9c432dd8cece69c29d0bafa901e98160153dacb5e1d5fb45e8d47ba1d7": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "newValue": "0x72734554482f7773744554480000000000000000000000000000000000000018"
-        },
-        "0xb6395f9c432dd8cece69c29d0bafa901e98160153dacb5e1d5fb45e8d47ba1d8": {
-          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000002"
+        "0x81d0999fde243adcc41b7fa1be5cea14f789e3a6065b815ac58f4bc0838c3156": {
+          "previousValue": "0x7273455448204c5354206d61696e00000000000000000000000000000000001c",
+          "newValue": "0x7273455448204c5354206d61696e00000000000000000000000000000000001c"
         }
       }
     },

--- a/diffs/AaveV3Ethereum_LRTAndWstETHUnification_20250430_before_AaveV3Ethereum_LRTAndWstETHUnification_20250430_after.md
+++ b/diffs/AaveV3Ethereum_LRTAndWstETHUnification_20250430_before_AaveV3Ethereum_LRTAndWstETHUnification_20250430_after.md
@@ -1,0 +1,96 @@
+## Emodes changed
+
+### EMode: ETH correlated(id: 1)
+
+
+
+### EMode: sUSDe Stablecoins(id: 2)
+
+
+
+### EMode: rsETH LST main(id: 3)
+
+
+
+### EMode: LBTC_WBTC(id: 4)
+
+
+
+### EMode: LBTC_cbBTC(id: 5)
+
+
+
+### EMode: LBTC_tBTC(id: 6)
+
+
+
+### EMode: eBTC/WBTC(id: 7)
+
+
+
+### EMode: rsETH/wstETH(id: 8)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label | - | rsETH/wstETH |
+| eMode.ltv | - | 93 % |
+| eMode.liquidationThreshold | - | 95 % |
+| eMode.liquidationBonus | - | 1 % |
+| eMode.borrowableBitmap | - | wstETH |
+| eMode.collateralBitmap | - | rsETH |
+
+
+## Raw diff
+
+```json
+{
+  "eModes": {
+    "8": {
+      "from": null,
+      "to": {
+        "borrowableBitmap": "2",
+        "collateralBitmap": "68719476736",
+        "eModeCategory": 8,
+        "label": "rsETH/wstETH",
+        "liquidationBonus": 10100,
+        "liquidationThreshold": 9500,
+        "ltv": 9300
+      }
+    }
+  },
+  "raw": {
+    "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2": {
+      "label": "AaveV3Ethereum.POOL",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481917": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000000000000000000000010000000002774251c2454"
+        },
+        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481918": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x72734554482f7773744554480000000000000000000000000000000000000018"
+        },
+        "0xe1eef7f3dc95a7682cb02e33f0d6a7c6e59cd5f4d1f5d7b4e6308bb610481919": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000002"
+        }
+      }
+    },
+    "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x57c0d0964870c24387de1cb96a1c0d1e031544394130654a48994b8a35b62a81": {
+          "previousValue": "0x0068114f4a000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068114f4a000000000003000000000000000000000000000000000000000000"
+        },
+        "0x57c0d0964870c24387de1cb96a1c0d1e031544394130654a48994b8a35b62a82": {
+          "previousValue": "0x000000000000000000093a80000000000000683f73cb00000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000683f73cb00000000000068114f4b"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3ArbitrumAssets, AaveV3ArbitrumEModes} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {AaveV3PayloadArbitrum} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadArbitrum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title LRT and wstETH Unification
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
+ */
+contract AaveV3Arbitrum_LRTAndWstETHUnification_20250430 is AaveV3PayloadArbitrum {
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3ArbitrumAssets.weETH_UNDERLYING,
+      ltv: 75_00,
+      liqThreshold: 77_00,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: EngineFlags.KEEP_CURRENT,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+
+    return collateralUpdate;
+  }
+
+  function eModeCategoriesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.EModeCategoryUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.EModeCategoryUpdate[]
+      memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](2);
+
+    eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: AaveV3ArbitrumEModes.RSETH_WSTETH,
+      ltv: 93_00,
+      liqThreshold: 95_00,
+      liqBonus: 1_00,
+      label: EngineFlags.KEEP_CURRENT_STRING
+    });
+
+    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 6,
+      ltv: 72_00,
+      liqThreshold: 75_00,
+      liqBonus: 7_50,
+      label: 'rsETH/Stablecoins'
+    });
+
+    return eModeUpdates;
+  }
+
+  function assetsEModeUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.AssetEModeUpdate[]
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](3);
+
+    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3ArbitrumAssets.rsETH_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+    assetEModeUpdates[1] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3ArbitrumAssets.USDC_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[2] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3ArbitrumAssets.USDT_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+
+    return assetEModeUpdates;
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol
@@ -13,27 +13,6 @@ import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config
  * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
  */
 contract AaveV3Arbitrum_LRTAndWstETHUnification_20250430 is AaveV3PayloadArbitrum {
-  function collateralsUpdates()
-    public
-    pure
-    override
-    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
-  {
-    IAaveV3ConfigEngine.CollateralUpdate[]
-      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
-
-    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
-      asset: AaveV3ArbitrumAssets.weETH_UNDERLYING,
-      ltv: 75_00,
-      liqThreshold: 77_00,
-      liqBonus: EngineFlags.KEEP_CURRENT,
-      debtCeiling: EngineFlags.KEEP_CURRENT,
-      liqProtocolFee: EngineFlags.KEEP_CURRENT
-    });
-
-    return collateralUpdate;
-  }
-
   function eModeCategoriesUpdates()
     public
     pure

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.t.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Arbitrum} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+
+import {AaveV3Arbitrum_LRTAndWstETHUnification_20250430} from './AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol';
+
+/**
+ * @dev Test for AaveV3Arbitrum_LRTAndWstETHUnification_20250430
+ * command: FOUNDRY_PROFILE=arbitrum forge test --match-path=src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.t.sol -vv
+ */
+contract AaveV3Arbitrum_LRTAndWstETHUnification_20250430_Test is ProtocolV3TestBase {
+  AaveV3Arbitrum_LRTAndWstETHUnification_20250430 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('arbitrum'), 331579415);
+    proposal = new AaveV3Arbitrum_LRTAndWstETHUnification_20250430();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Arbitrum_LRTAndWstETHUnification_20250430',
+      AaveV3Arbitrum.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3BaseAssets, AaveV3BaseEModes} from 'aave-address-book/AaveV3Base.sol';
+import {AaveV3PayloadBase} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadBase.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title LRT and wstETH Unification
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
+ */
+contract AaveV3Base_LRTAndWstETHUnification_20250430 is AaveV3PayloadBase {
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3BaseAssets.weETH_UNDERLYING,
+      ltv: 75_00,
+      liqThreshold: 77_00,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: EngineFlags.KEEP_CURRENT,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+
+    return collateralUpdate;
+  }
+
+  function eModeCategoriesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.EModeCategoryUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.EModeCategoryUpdate[]
+      memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](5);
+
+    eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: AaveV3BaseEModes.RSETH_WSTETH,
+      ltv: 93_00,
+      liqThreshold: 95_00,
+      liqBonus: 1_00,
+      label: EngineFlags.KEEP_CURRENT_STRING
+    });
+    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 6,
+      ltv: 72_00,
+      liqThreshold: 75_00,
+      liqBonus: 7_50,
+      label: 'rsETH/USDC'
+    });
+    eModeUpdates[2] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 7,
+      ltv: 93_00,
+      liqThreshold: 95_00,
+      liqBonus: 1_25,
+      label: 'weETH/WETH'
+    });
+    eModeUpdates[3] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 8,
+      ltv: 93_00,
+      liqThreshold: 95_00,
+      liqBonus: 1_00,
+      label: 'wstETH/WETH'
+    });
+    eModeUpdates[4] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 9,
+      ltv: 93_00,
+      liqThreshold: 95_00,
+      liqBonus: 2_00,
+      label: 'cbETH/WETH'
+    });
+
+    return eModeUpdates;
+  }
+
+  function assetsEModeUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.AssetEModeUpdate[]
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](8);
+
+    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.USDC_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[1] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.wrsETH_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+
+    assetEModeUpdates[2] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.WETH_UNDERLYING,
+      eModeCategory: 7,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[3] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.weETH_UNDERLYING,
+      eModeCategory: 7,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+
+    assetEModeUpdates[4] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.WETH_UNDERLYING,
+      eModeCategory: 8,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[5] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.wstETH_UNDERLYING,
+      eModeCategory: 8,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+
+    assetEModeUpdates[6] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.WETH_UNDERLYING,
+      eModeCategory: 9,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[7] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.cbETH_UNDERLYING,
+      eModeCategory: 9,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+
+    return assetEModeUpdates;
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol
@@ -13,27 +13,6 @@ import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config
  * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
  */
 contract AaveV3Base_LRTAndWstETHUnification_20250430 is AaveV3PayloadBase {
-  function collateralsUpdates()
-    public
-    pure
-    override
-    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
-  {
-    IAaveV3ConfigEngine.CollateralUpdate[]
-      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
-
-    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
-      asset: AaveV3BaseAssets.weETH_UNDERLYING,
-      ltv: 75_00,
-      liqThreshold: 77_00,
-      liqBonus: EngineFlags.KEEP_CURRENT,
-      debtCeiling: EngineFlags.KEEP_CURRENT,
-      liqProtocolFee: EngineFlags.KEEP_CURRENT
-    });
-
-    return collateralUpdate;
-  }
-
   function eModeCategoriesUpdates()
     public
     pure
@@ -89,7 +68,7 @@ contract AaveV3Base_LRTAndWstETHUnification_20250430 is AaveV3PayloadBase {
     returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
   {
     IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](9);
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](8);
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3BaseAssets.USDC_UNDERLYING,
@@ -141,12 +120,6 @@ contract AaveV3Base_LRTAndWstETHUnification_20250430 is AaveV3PayloadBase {
       eModeCategory: 9,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.ENABLED
-    });
-    assetEModeUpdates[8] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3BaseAssets.WETH_UNDERLYING,
-      eModeCategory: AaveV3BaseEModes.ETH_CORRELATED,
-      borrowable: EngineFlags.DISABLED,
-      collateral: EngineFlags.DISABLED
     });
 
     return assetEModeUpdates;

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol
@@ -89,7 +89,7 @@ contract AaveV3Base_LRTAndWstETHUnification_20250430 is AaveV3PayloadBase {
     returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
   {
     IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](8);
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](9);
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3BaseAssets.USDC_UNDERLYING,
@@ -141,6 +141,12 @@ contract AaveV3Base_LRTAndWstETHUnification_20250430 is AaveV3PayloadBase {
       eModeCategory: 9,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.ENABLED
+    });
+    assetEModeUpdates[8] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3BaseAssets.WETH_UNDERLYING,
+      eModeCategory: AaveV3BaseEModes.ETH_CORRELATED,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.DISABLED
     });
 
     return assetEModeUpdates;

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.t.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Base} from 'aave-address-book/AaveV3Base.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+
+import {AaveV3Base_LRTAndWstETHUnification_20250430} from './AaveV3Base_LRTAndWstETHUnification_20250430.sol';
+
+/**
+ * @dev Test for AaveV3Base_LRTAndWstETHUnification_20250430
+ * command: FOUNDRY_PROFILE=base forge test --match-path=src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.t.sol -vv
+ */
+contract AaveV3Base_LRTAndWstETHUnification_20250430_Test is ProtocolV3TestBase {
+  AaveV3Base_LRTAndWstETHUnification_20250430 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('base'), 29587769);
+    proposal = new AaveV3Base_LRTAndWstETHUnification_20250430();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest('AaveV3Base_LRTAndWstETHUnification_20250430', AaveV3Base.POOL, address(proposal));
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
@@ -52,18 +52,18 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
       memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](2);
 
     eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
-      eModeCategory: AaveV3EthereumLidoEModes.ETH_CORRELATED,
-      ltv: 95_00,
-      liqThreshold: 96_50,
-      liqBonus: 1_00,
-      label: 'wstETH/WETH'
-    });
-    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
       eModeCategory: 6,
       ltv: 72_00,
       liqThreshold: 75_00,
       liqBonus: 7_50,
       label: 'rsETH/Stablecoins'
+    });
+    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 7,
+      ltv: 95_00,
+      liqThreshold: 96_50,
+      liqBonus: 1_00,
+      label: 'wstETH/WETH'
     });
 
     return eModeUpdates;
@@ -76,7 +76,7 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
     returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
   {
     IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](4);
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](5);
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumLidoAssets.USDC_UNDERLYING,
@@ -101,6 +101,12 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
       eModeCategory: 6,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.ENABLED
+    });
+    assetEModeUpdates[4] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.WETH_UNDERLYING,
+      eModeCategory: AaveV3EthereumLidoEModes.ETH_CORRELATED,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.DISABLED
     });
 
     return assetEModeUpdates;

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
@@ -13,35 +13,6 @@ import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config
  * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
  */
 contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereumLido {
-  function collateralsUpdates()
-    public
-    pure
-    override
-    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
-  {
-    IAaveV3ConfigEngine.CollateralUpdate[]
-      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](2);
-
-    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
-      asset: AaveV3EthereumLidoAssets.wstETH_UNDERLYING,
-      ltv: 82_00,
-      liqThreshold: 83_00,
-      liqBonus: EngineFlags.KEEP_CURRENT,
-      debtCeiling: EngineFlags.KEEP_CURRENT,
-      liqProtocolFee: EngineFlags.KEEP_CURRENT
-    });
-    collateralUpdate[1] = IAaveV3ConfigEngine.CollateralUpdate({
-      asset: AaveV3EthereumLidoAssets.WETH_UNDERLYING,
-      ltv: 84_00,
-      liqThreshold: 85_00,
-      liqBonus: EngineFlags.KEEP_CURRENT,
-      debtCeiling: EngineFlags.KEEP_CURRENT,
-      liqProtocolFee: EngineFlags.KEEP_CURRENT
-    });
-
-    return collateralUpdate;
-  }
-
   function eModeCategoriesUpdates()
     public
     pure
@@ -50,20 +21,19 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
   {
     IAaveV3ConfigEngine.EModeCategoryUpdate[]
       memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](2);
-
     eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: AaveV3EthereumLidoEModes.ETH_CORRELATED,
+      ltv: 95_00,
+      liqThreshold: 96_50,
+      liqBonus: 1_00,
+      label: 'wstETH/WETH'
+    });
+    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
       eModeCategory: 6,
       ltv: 72_00,
       liqThreshold: 75_00,
       liqBonus: 7_50,
       label: 'rsETH/Stablecoins'
-    });
-    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
-      eModeCategory: 7,
-      ltv: 95_00,
-      liqThreshold: 96_50,
-      liqBonus: 1_00,
-      label: 'wstETH/WETH'
     });
 
     return eModeUpdates;
@@ -76,7 +46,7 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
     returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
   {
     IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](7);
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](4);
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumLidoAssets.USDC_UNDERLYING,
@@ -99,24 +69,6 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
     assetEModeUpdates[3] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumLidoAssets.rsETH_UNDERLYING,
       eModeCategory: 6,
-      borrowable: EngineFlags.DISABLED,
-      collateral: EngineFlags.ENABLED
-    });
-    assetEModeUpdates[4] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumLidoAssets.WETH_UNDERLYING,
-      eModeCategory: AaveV3EthereumLidoEModes.ETH_CORRELATED,
-      borrowable: EngineFlags.DISABLED,
-      collateral: EngineFlags.DISABLED
-    });
-    assetEModeUpdates[5] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumLidoAssets.WETH_UNDERLYING,
-      eModeCategory: 7,
-      borrowable: EngineFlags.ENABLED,
-      collateral: EngineFlags.DISABLED
-    });
-    assetEModeUpdates[6] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumLidoAssets.wstETH_UNDERLYING,
-      eModeCategory: 7,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.ENABLED
     });

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLidoAssets, AaveV3EthereumLidoEModes} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {AaveV3PayloadEthereumLido} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereumLido.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title LRT and wstETH Unification
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
+ */
+contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereumLido {
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](2);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumLidoAssets.wstETH_UNDERLYING,
+      ltv: 82_00,
+      liqThreshold: 83_00,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: EngineFlags.KEEP_CURRENT,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+    collateralUpdate[1] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumLidoAssets.WETH_UNDERLYING,
+      ltv: 84_00,
+      liqThreshold: 85_00,
+      liqBonus: EngineFlags.KEEP_CURRENT,
+      debtCeiling: EngineFlags.KEEP_CURRENT,
+      liqProtocolFee: EngineFlags.KEEP_CURRENT
+    });
+
+    return collateralUpdate;
+  }
+
+  function eModeCategoriesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.EModeCategoryUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.EModeCategoryUpdate[]
+      memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](2);
+
+    eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: AaveV3EthereumLidoEModes.ETH_CORRELATED,
+      ltv: 95_00,
+      liqThreshold: 96_50,
+      liqBonus: 1_00,
+      label: 'wstETH/WETH'
+    });
+    eModeUpdates[1] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 6,
+      ltv: 72_00,
+      liqThreshold: 75_00,
+      liqBonus: 7_50,
+      label: 'rsETH/Stablecoins'
+    });
+
+    return eModeUpdates;
+  }
+
+  function assetsEModeUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.AssetEModeUpdate[]
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](4);
+
+    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.USDC_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[1] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.USDS_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[2] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.GHO_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[3] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.rsETH_UNDERLYING,
+      eModeCategory: 6,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+
+    return assetEModeUpdates;
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol
@@ -76,7 +76,7 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
     returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
   {
     IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](5);
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](7);
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumLidoAssets.USDC_UNDERLYING,
@@ -107,6 +107,18 @@ contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430 is AaveV3PayloadEth
       eModeCategory: AaveV3EthereumLidoEModes.ETH_CORRELATED,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[5] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.WETH_UNDERLYING,
+      eModeCategory: 7,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[6] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumLidoAssets.wstETH_UNDERLYING,
+      eModeCategory: 7,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
     });
 
     return assetEModeUpdates;

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.t.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLido} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+
+import {AaveV3EthereumLido_LRTAndWstETHUnification_20250430} from './AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol';
+
+/**
+ * @dev Test for AaveV3EthereumLido_LRTAndWstETHUnification_20250430
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.t.sol -vv
+ */
+contract AaveV3EthereumLido_LRTAndWstETHUnification_20250430_Test is ProtocolV3TestBase {
+  AaveV3EthereumLido_LRTAndWstETHUnification_20250430 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22377625);
+    proposal = new AaveV3EthereumLido_LRTAndWstETHUnification_20250430();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3EthereumLido_LRTAndWstETHUnification_20250430',
+      AaveV3EthereumLido.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
@@ -23,7 +23,7 @@ contract AaveV3Ethereum_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereu
       memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](1);
 
     eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
-      eModeCategory: 8,
+      eModeCategory: 10,
       ltv: 93_00,
       liqThreshold: 95_00,
       liqBonus: 1_00,
@@ -44,13 +44,13 @@ contract AaveV3Ethereum_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereu
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
-      eModeCategory: 8,
+      eModeCategory: 10,
       borrowable: EngineFlags.ENABLED,
       collateral: EngineFlags.DISABLED
     });
     assetEModeUpdates[1] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumAssets.rsETH_UNDERLYING,
-      eModeCategory: 8,
+      eModeCategory: 10,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.ENABLED
     });

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
@@ -40,7 +40,7 @@ contract AaveV3Ethereum_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereu
     returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
   {
     IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](3);
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](2);
 
     assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
@@ -53,12 +53,6 @@ contract AaveV3Ethereum_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereu
       eModeCategory: 8,
       borrowable: EngineFlags.DISABLED,
       collateral: EngineFlags.ENABLED
-    });
-    assetEModeUpdates[2] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
-      eModeCategory: AaveV3EthereumEModes.RSETH_LST_MAIN,
-      borrowable: EngineFlags.DISABLED,
-      collateral: EngineFlags.DISABLED
     });
 
     return assetEModeUpdates;

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
@@ -23,38 +23,13 @@ contract AaveV3Ethereum_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereu
       memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](1);
 
     eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
-      eModeCategory: 10,
+      eModeCategory: 3,
       ltv: 93_00,
       liqThreshold: 95_00,
       liqBonus: 1_00,
-      label: 'rsETH/wstETH'
+      label: EngineFlags.KEEP_CURRENT_STRING
     });
 
     return eModeUpdates;
-  }
-
-  function assetsEModeUpdates()
-    public
-    pure
-    override
-    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
-  {
-    IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](2);
-
-    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
-      eModeCategory: 10,
-      borrowable: EngineFlags.ENABLED,
-      collateral: EngineFlags.DISABLED
-    });
-    assetEModeUpdates[1] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumAssets.rsETH_UNDERLYING,
-      eModeCategory: 10,
-      borrowable: EngineFlags.DISABLED,
-      collateral: EngineFlags.ENABLED
-    });
-
-    return assetEModeUpdates;
   }
 }

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumAssets, AaveV3EthereumEModes} from 'aave-address-book/AaveV3Ethereum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {AaveV3PayloadEthereum} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereum.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title LRT and wstETH Unification
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739
+ */
+contract AaveV3Ethereum_LRTAndWstETHUnification_20250430 is AaveV3PayloadEthereum {
+  function eModeCategoriesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.EModeCategoryUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.EModeCategoryUpdate[]
+      memory eModeUpdates = new IAaveV3ConfigEngine.EModeCategoryUpdate[](1);
+
+    eModeUpdates[0] = IAaveV3ConfigEngine.EModeCategoryUpdate({
+      eModeCategory: 8,
+      ltv: 93_00,
+      liqThreshold: 95_00,
+      liqBonus: 1_00,
+      label: 'rsETH/wstETH'
+    });
+
+    return eModeUpdates;
+  }
+
+  function assetsEModeUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.AssetEModeUpdate[]
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](3);
+
+    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
+      eModeCategory: 8,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.DISABLED
+    });
+    assetEModeUpdates[1] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumAssets.rsETH_UNDERLYING,
+      eModeCategory: 8,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.ENABLED
+    });
+    assetEModeUpdates[2] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
+      eModeCategory: AaveV3EthereumEModes.RSETH_LST_MAIN,
+      borrowable: EngineFlags.DISABLED,
+      collateral: EngineFlags.DISABLED
+    });
+
+    return assetEModeUpdates;
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.t.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+
+import {AaveV3Ethereum_LRTAndWstETHUnification_20250430} from './AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_LRTAndWstETHUnification_20250430
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.t.sol -vv
+ */
+contract AaveV3Ethereum_LRTAndWstETHUnification_20250430_Test is ProtocolV3TestBase {
+  AaveV3Ethereum_LRTAndWstETHUnification_20250430 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22377625);
+    proposal = new AaveV3Ethereum_LRTAndWstETHUnification_20250430();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Ethereum_LRTAndWstETHUnification_20250430',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.t.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.t.sol
@@ -14,7 +14,7 @@ contract AaveV3Ethereum_LRTAndWstETHUnification_20250430_Test is ProtocolV3TestB
   AaveV3Ethereum_LRTAndWstETHUnification_20250430 internal proposal;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22377625);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22446550);
     proposal = new AaveV3Ethereum_LRTAndWstETHUnification_20250430();
   }
 

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -53,7 +53,7 @@ Update the current wstETH/wETH eMode
 |      Collaterals      | wstETH |
 |      Borrowable       |  WETH  |
 
-Create new asset eMode
+Create new rsETH/Stablecoins eMode
 
 |       Parameter       |      Value      |
 | :-------------------: | :-------------: |
@@ -87,7 +87,7 @@ Update the current rsETH/wstETH
 |      Collaterals      | rsETH  |
 |      Borrowable       | wstETH |
 
-Create new asset eMode
+Create new rsETH/Stablecoins eMode
 
 |       Parameter       |   Value    |
 | :-------------------: | :--------: |
@@ -109,7 +109,7 @@ Update the current rsETH/wstETH eMode
 |      Collaterals      | rsETH  |
 |      Borrowable       | wstETH |
 
-Create new asset eMode
+Create new rsETH/USDC eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -119,7 +119,7 @@ Create new asset eMode
 |      Collaterals      | rsETH  |
 |      Borrowable       |  USDC  |
 
-Create new asset eMode
+Create new weETH/wETH eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -129,7 +129,7 @@ Create new asset eMode
 |      Collaterals      | weETH  |
 |      Borrowable       |  wETH  |
 
-Create new asset eMode
+Create new wstETH/wETH eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -139,7 +139,7 @@ Create new asset eMode
 |      Collaterals      | wstETH |
 |      Borrowable       |  wETH  |
 
-Create new asset eMode
+Create new cbETH/WETH eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -45,12 +45,14 @@ The following adjustments are to be implemented on all instances within the same
 
 Update the current wstETH/wETH eMode
 
-|       Parameter       |    Value     |
-| :-------------------: | :----------: |
-|         Asset         | wstETH, WETH |
-|        Max LTV        |     95.0     |
-| Liquidation Threshold |     96.5     |
-|  Liquidation Penalty  |    1.00%     |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | wstETH |
+|        Max LTV        |  95.0  |
+| Liquidation Threshold |  96.5  |
+|  Liquidation Penalty  | 1.00%  |
+|      Collaterals      | wstETH |
+|      Borrowable       |  WETH  |
 
 Create new v3.2 liquid eMode
 
@@ -69,16 +71,16 @@ Create new v3.2 liquid eMode
 
 rsETH/wstETH liquid eMode update.
 
-|       Parameter       | Value  |
-| :-------------------: | :----: |
-|         Asset         | rsETH  |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
-|        Max LTV        | 93.00% |
-| Liquidation Threshold | 95.00% |
-|  Liquidation Penalty  | 1.00%  |
-|      Collaterals      | rsETH  |
-|      Borrowable       | wstETH |
+|       Parameter       |    Value     |
+| :-------------------: | :----------: |
+|         Asset         |    rsETH     |
+|      Collateral       |     Yes      |
+|      Borrowable       |      No      |
+|        Max LTV        |    93.00%    |
+| Liquidation Threshold |    95.00%    |
+|  Liquidation Penalty  |    1.00%     |
+|      Collaterals      |    rsETH     |
+|      Borrowable       | wstETH, ETHx |
 
 ### Arbitrum
 

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -65,7 +65,7 @@ Create new asset eMode
 
 ### Core - Ethereum
 
-rsETH/wstETH liquid eMode update.
+Update the current rsETH/wstETH
 
 |       Parameter       |    Value     |
 | :-------------------: | :----------: |
@@ -77,7 +77,7 @@ rsETH/wstETH liquid eMode update.
 
 ### Arbitrum
 
-rsETH/wstETH liquid eMode update.
+Update the current rsETH/wstETH
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -87,7 +87,7 @@ rsETH/wstETH liquid eMode update.
 |      Collaterals      | rsETH  |
 |      Borrowable       | wstETH |
 
-Create new v3.2 liquid eMode
+Create new asset eMode
 
 |       Parameter       |   Value    |
 | :-------------------: | :--------: |
@@ -99,7 +99,7 @@ Create new v3.2 liquid eMode
 
 ### Base
 
-Update rsETH/wstETH liquid eMode.
+Update the current rsETH/wstETH eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -109,7 +109,7 @@ Update rsETH/wstETH liquid eMode.
 |      Collaterals      | rsETH  |
 |      Borrowable       | wstETH |
 
-Create new v3.2 liquid eMode
+Create new asset eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -119,7 +119,7 @@ Create new v3.2 liquid eMode
 |      Collaterals      | rsETH  |
 |      Borrowable       |  USDC  |
 
-Create weETH/wETH liquid eMode.
+Create new asset eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -129,7 +129,7 @@ Create weETH/wETH liquid eMode.
 |      Collaterals      | weETH  |
 |      Borrowable       |  wETH  |
 
-Create wstETH/WETH eMode
+Create new asset eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
@@ -139,7 +139,7 @@ Create wstETH/WETH eMode
 |      Collaterals      | wstETH |
 |      Borrowable       |  wETH  |
 
-Create cbETH/WETH eMode Update
+Create new asset eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -47,18 +47,16 @@ Update the current wstETH/wETH eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | wstETH |
 |        Max LTV        |  95.0  |
 | Liquidation Threshold |  96.5  |
 |  Liquidation Penalty  | 1.00%  |
 |      Collaterals      | wstETH |
 |      Borrowable       |  WETH  |
 
-Create new v3.2 liquid eMode
+Create new asset eMode
 
 |       Parameter       |      Value      |
 | :-------------------: | :-------------: |
-|         Asset         |      rsETH      |
 |        Max LTV        |     72.00%      |
 | Liquidation Threshold |     75.00%      |
 |  Liquidation Penalty  |      7.50%      |
@@ -71,7 +69,6 @@ rsETH/wstETH liquid eMode update.
 
 |       Parameter       |    Value     |
 | :-------------------: | :----------: |
-|         Asset         |    rsETH     |
 |        Max LTV        |    93.00%    |
 | Liquidation Threshold |    95.00%    |
 |  Liquidation Penalty  |    1.00%     |
@@ -84,7 +81,6 @@ rsETH/wstETH liquid eMode update.
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | rsETH  |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.00%  |
@@ -95,7 +91,6 @@ Create new v3.2 liquid eMode
 
 |       Parameter       |   Value    |
 | :-------------------: | :--------: |
-|         Asset         |   rsETH    |
 |        Max LTV        |   72.00%   |
 | Liquidation Threshold |   75.00%   |
 |  Liquidation Penalty  |   7.50%    |
@@ -108,7 +103,6 @@ Update rsETH/wstETH liquid eMode.
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | rsETH  |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.00%  |
@@ -119,7 +113,6 @@ Create new v3.2 liquid eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | rsETH  |
 |        Max LTV        | 72.00% |
 | Liquidation Threshold | 75.00% |
 |  Liquidation Penalty  | 7.50%  |
@@ -130,7 +123,6 @@ Create weETH/wETH liquid eMode.
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | weETH  |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.25%  |
@@ -141,7 +133,6 @@ Create wstETH/WETH eMode
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | wstETH |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.00%  |
@@ -152,7 +143,6 @@ Create cbETH/WETH eMode Update
 
 |       Parameter       | Value  |
 | :-------------------: | :----: |
-|         Asset         | cbETH  |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 2.00%  |

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -25,37 +25,6 @@ The Prime instance, previously Lido instance, presents a tailored wstETH eMode c
 
 With all other variables held constant, a small difference in the wstETH deposit yield on Prime relative to the Core instance, has a meaningful impact on the overall return of the wstETH/WETH yield strategy. With a strong focus on sustaining a wstETH deposit yield derived from LRT/wstETH leverage, the wstETH/WETH yield strategy is expected to outperform on Prime relative to other venues supporting the same wstETH/WETH strategy.
 
-Provided suitable ETH liquidity is available, implementing favourable eMode terms on Prime relative to other instances of Aave is expected to lead to significant growth in wstETH deposits. A LT of 96.50% exceeds the previous forum discussion supportive of implementing a 96.00% LT, whilst also isolating the LT increase specifically to the Prime instance that reflects a clear focus to progress Prime into a sustainable ETH correlated instance of Aave v3.
-
-Reference: [[Risk Stewards]wstETH/wETH eMode Update - Ethereum, Arbitrum & Base Instances](https://governance.aave.com/t/risk-stewards-wsteth-weth-emode-update-ethereum-arbitrum-base-instances/21333)
-
-#### wstETH/wETH Legacy eMode Update
-
-|       Parameter       |    Value     |
-| :-------------------: | :----------: |
-|         Asset         | wstETH, WETH |
-|        Max LTV        |     95.0     |
-| Liquidation Threshold |     96.5     |
-|  Liquidation Penalty  |    1.00%     |
-
-Complimenting the abundance of USDS liquidity provided by the Sky Ecosystem via D3M, this publication proposes increasing the LTV and LT on Prime to improve the capital efficiency of WETH and wstETH relative to other instances of Aave v3. With the support of Sky via D3M and Gho Stewards via Direct Gho Minter Facilitator providing liquidity on demand, the Prime instance is able to offer consistent stablecoin supply and less volatile borrow rates to users.
-
-The combination of improved capital efficiency and less volatile borrow rates elevates the competitive positioning of the Prime instances within the broader ecosystem.
-
-#### WETH LTV/LT Update
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    | 82.00%  |  84.00%  |
-|    LT     | 83.00%  |  85.00%  |
-
-#### wstETH LTV/LT Update
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    | 80.00%  |  82.00%  |
-|    LT     | 81.00%  |  83.00%  |
-
 ### rsETH LTV & LT Update
 
 To promote a level playing field between LRTs, a proposal was submitted and approved by Risk Service Providers to align the LTV and LT parameters of rsETH with other LRTs, ezETH and weETH.
@@ -64,130 +33,9 @@ The following is proposed for rsETH Core, Prime and Base instances:
 
 - Update rsETH/wstETH eMode: LTV 93%, LT 95% and Liquidation Penalty 1%.
 
-A previous forum post details favourable feedback from Risk Service providers supporting amending the LTV and LT to align with other LRTs.
-
-Reference: [[ARFC] rsETH LTV & LT Update](https://governance.aave.com/t/arfc-rseth-ltv-lt-update/21305/1)
-
-#### rsETH/wstETH eMode Update
-
-(Prime, Core, Arbitrum and Base)
-
-|       Parameter       | Value  | Value  |
-| :-------------------: | :----: | :----: |
-|         Asset         | rsETH  | wstETH |
-|      Collateral       |  Yes   |   No   |
-|      Borrowable       |   No   |  Yes   |
-|        Max LTV        | 93.00% |   -    |
-| Liquidation Threshold | 95.00% |   -    |
-|  Liquidation Penalty  | 1.00%  |   -    |
-
-Enable rsETH to access stablecoin liquidity on Prime, Arbitrum and Base instances.
-
-#### Create new v3.2 liquid eMode
-
-(Prime)
-
-|       Parameter       | Value  | Value | Value | Value |
-| :-------------------: | :----: | :---: | :---: | :---: |
-|         Asset         | rsETH  | USDS  | USDC  |  GHO  |
-|      Collateral       |  Yes   |  No   |  No   |  No   |
-|      Borrowable       |   No   |  Yes  |  Yes  |  Yes  |
-|        Max LTV        | 72.00% |   -   |   -   |   -   |
-| Liquidation Threshold | 75.00% |   -   |   -   |   -   |
-|  Liquidation Penalty  | 7.50%  |   -   |   -   |   -   |
-
-#### Create new v3.2 liquid eMode
-
-(Arbitrum)
-
-|       Parameter       | Value  | Value | Value |
-| :-------------------: | :----: | :---: | :---: |
-|         Asset         | rsETH  | USDC  | USDT  |
-|      Collateral       |  Yes   |  No   |  No   |
-|      Borrowable       |   No   |  Yes  |  Yes  |
-|        Max LTV        | 72.00% |   -   |   -   |
-| Liquidation Threshold | 75.00% |   -   |   -   |
-|  Liquidation Penalty  | 7.50%  |   -   |   -   |
-
-#### Create new v3.2 liquid eMode
-
-(Base)
-
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | rsETH  | USDC  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 72.00% |   -   |
-| Liquidation Threshold | 75.00% |   -   |
-|  Liquidation Penalty  | 7.50%  |   -   |
-
-### weETH LTV & LT Update
-
-Based upon improving liquidity conditions on both Arbitrum and Base for weETH, this publication proposes increasing the weETH LTV and LTV as recommended by the Chaos Labs and Llama Risk in the reference linked below.
-
-#### weETH LTV/LT Update
-
-(Arb and Base)
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    |  72.5%  |   75%    |
-|    LT     |   75%   |   77%    |
-
-Reference: [[ARFC] wstETH and weETH E-Modes and LT/LTV Adjustments on Ethereum, Arbitrum, Base - 03.12.25](https://governance.aave.com/t/arfc-wsteth-and-weeth-e-modes-and-lt-ltv-adjustments-on-ethereum-arbitrum-base-03-12-25/21370)
-
-### Base Instance - Liquid eMode v3.2
+### EModes
 
 The introduction of Liquid eModes in Aave v3.2 enables more granular and targeted risk configurations between correlated assets such as LSTs and LRTs. Creating isolated eModes for each pair enhances capital efficiency relative to the current ETH-correlated eModes on the Base instance.
-
-Currently, Aave Protocol supports a single ETH Correlated eMode on Base.
-
-|       Parameter       |           Value            |
-| :-------------------: | :------------------------: |
-|         Asset         | weETH, wstETH, cbETH, WETH |
-|        Max LTV        |           90.00%           |
-| Liquidation Threshold |           93.00%           |
-|  Liquidation Penalty  |           2.00%            |
-
-To align the asset parameter configuration on Base instance with other instances of Aave, new v3.2 Liquid eModes are to be deployed with the following parameters. Each new eMode reflects the LTV and LT in use on the Core instance on Ethereum and in doing so unifies the parameters across Core, Arb and Base. Furthermore, by pausing the existing ETH correlated eMode and transitioning to more capital efficient v3.2 eModes, it prevents same-asset looping that undermines liquidity incentives from unintended utilisation.
-
-#### weETH/WETH eMode Update
-
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | weETH  | wETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 93.00% |   -   |
-| Liquidation Threshold | 95.00% |   -   |
-|  Liquidation Penalty  | 1.25%  |   -   |
-
-#### wstETH/WETH eMode Update
-
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | wstETH | wETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 93.00% |   -   |
-| Liquidation Threshold | 95.00% |   -   |
-|  Liquidation Penalty  | 1.00%  |   -   |
-
-#### cbETH/WETH eMode Update
-
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | cbETH  | wETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 93.00% |   -   |
-| Liquidation Threshold | 95.00% |   -   |
-|  Liquidation Penalty  | 2.00%  |   -   |
-
-The above new weETH eModes incorporates the feedback from the forum discussion linked below.
-
-Reference: [[ARFC] wstETH and weETH E-Modes and LT/LTV Adjustments on Ethereum, Arbitrum, Base - 03.12.25](https://governance.aave.com/t/arfc-wsteth-and-weeth-e-modes-and-lt-ltv-adjustments-on-ethereum-arbitrum-base-03-12-25/21370)
 
 ## Specification
 
@@ -206,108 +54,126 @@ Update the current wstETH/wETH eMode
 
 Create new v3.2 liquid eMode
 
-|       Parameter       | Value  | Value | Value | Value |
-| :-------------------: | :----: | :---: | :---: | :---: |
-|         Asset         | rsETH  | USDS  | USDC  |  GHO  |
-|      Collateral       |  Yes   |  No   |  No   |  No   |
-|      Borrowable       |   No   |  Yes  |  Yes  |  Yes  |
-|        Max LTV        | 72.00% |   -   |   -   |   -   |
-| Liquidation Threshold | 75.00% |   -   |   -   |   -   |
-|  Liquidation Penalty  | 7.50%  |   -   |   -   |   -   |
+|       Parameter       |      Value      |
+| :-------------------: | :-------------: |
+|         Asset         |      rsETH      |
+|      Collateral       |       Yes       |
+|      Borrowable       |       No        |
+|        Max LTV        |     72.00%      |
+| Liquidation Threshold |     75.00%      |
+|  Liquidation Penalty  |      7.50%      |
+|      Collaterals      |      rsETH      |
+|      Borrowable       | USDS, USDC, GHO |
 
 ### Core - Ethereum
 
 rsETH/wstETH liquid eMode update.
 
-|       Parameter       | Value  | Value  |
-| :-------------------: | :----: | :----: |
-|         Asset         | rsETH  | wstETH |
-|      Collateral       |  Yes   |   No   |
-|      Borrowable       |   No   |  Yes   |
-|        Max LTV        | 93.00% |   -    |
-| Liquidation Threshold | 95.00% |   -    |
-|  Liquidation Penalty  | 1.00%  |   -    |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | rsETH  |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 93.00% |
+| Liquidation Threshold | 95.00% |
+|  Liquidation Penalty  | 1.00%  |
+|      Collaterals      | rsETH  |
+|      Borrowable       | wstETH |
 
 ### Arbitrum
 
 rsETH/wstETH liquid eMode update.
 
-|       Parameter       | Value  | Value  |
-| :-------------------: | :----: | :----: |
-|         Asset         | rsETH  | wstETH |
-|      Collateral       |  Yes   |   No   |
-|      Borrowable       |   No   |  Yes   |
-|        Max LTV        | 93.00% |   -    |
-| Liquidation Threshold | 95.00% |   -    |
-|  Liquidation Penalty  | 1.00%  |   -    |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | rsETH  |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 93.00% |
+| Liquidation Threshold | 95.00% |
+|  Liquidation Penalty  | 1.00%  |
+|      Collaterals      | rsETH  |
+|      Borrowable       | wstETH |
 
 Create new v3.2 liquid eMode
 
-|       Parameter       | Value  | Value | Value |
-| :-------------------: | :----: | :---: | :---: |
-|         Asset         | rsETH  | USDC  | USDT  |
-|      Collateral       |  Yes   |  No   |  No   |
-|      Borrowable       |   No   |  Yes  |  Yes  |
-|        Max LTV        | 72.00% |   -   |   -   |
-| Liquidation Threshold | 75.00% |   -   |   -   |
-|  Liquidation Penalty  | 7.50%  |   -   |   -   |
+|       Parameter       |   Value    |
+| :-------------------: | :--------: |
+|         Asset         |   rsETH    |
+|      Collateral       |    Yes     |
+|      Borrowable       |     No     |
+|        Max LTV        |   72.00%   |
+| Liquidation Threshold |   75.00%   |
+|  Liquidation Penalty  |   7.50%    |
+|      Collaterals      |   rsETH    |
+|      Borrowable       | USDC, USDT |
 
 ### Base
 
 Update rsETH/wstETH liquid eMode.
 
-|       Parameter       | Value  | Value  |
-| :-------------------: | :----: | :----: |
-|         Asset         | rsETH  | wstETH |
-|      Collateral       |  Yes   |   No   |
-|      Borrowable       |   No   |  Yes   |
-|        Max LTV        | 93.00% |   -    |
-| Liquidation Threshold | 95.00% |   -    |
-|  Liquidation Penalty  | 1.00%  |   -    |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | rsETH  |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 93.00% |
+| Liquidation Threshold | 95.00% |
+|  Liquidation Penalty  | 1.00%  |
+|      Collaterals      | rsETH  |
+|      Borrowable       | wstETH |
 
 Create new v3.2 liquid eMode
 
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | rsETH  | USDC  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 72.00% |   -   |
-| Liquidation Threshold | 75.00% |   -   |
-|  Liquidation Penalty  | 7.50%  |   -   |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | rsETH  |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 72.00% |
+| Liquidation Threshold | 75.00% |
+|  Liquidation Penalty  | 7.50%  |
+|      Collaterals      | rsETH  |
+|      Borrowable       |  USDC  |
 
 Create weETH/wETH liquid eMode.
 
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | weETH  | wETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 93.00% |   -   |
-| Liquidation Threshold | 95.00% |   -   |
-|  Liquidation Penalty  | 1.25%  |   -   |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | weETH  |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 93.00% |
+| Liquidation Threshold | 95.00% |
+|  Liquidation Penalty  | 1.25%  |
+|      Collaterals      | weETH  |
+|      Borrowable       |  wETH  |
 
 Create wstETH/WETH eMode
 
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | wstETH | wETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 93.00% |   -   |
-| Liquidation Threshold | 95.00% |   -   |
-|  Liquidation Penalty  | 1.00%  |   -   |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | wstETH |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 93.00% |
+| Liquidation Threshold | 95.00% |
+|  Liquidation Penalty  | 1.00%  |
+|      Collaterals      | wstETH |
+|      Borrowable       |  wETH  |
 
 Create cbETH/WETH eMode Update
 
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | cbETH  | wETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 93.00% |   -   |
-| Liquidation Threshold | 95.00% |   -   |
-|  Liquidation Penalty  | 2.00%  |   -   |
+|       Parameter       | Value  |
+| :-------------------: | :----: |
+|         Asset         | cbETH  |
+|      Collateral       |  Yes   |
+|      Borrowable       |   No   |
+|        Max LTV        | 93.00% |
+| Liquidation Threshold | 95.00% |
+|  Liquidation Penalty  | 2.00%  |
+|      Collaterals      | cbETH  |
+|      Borrowable       |  wETH  |
 
 Pause the existing eMode by disabling wETH Borrowing within existing eMode. Users will not be able to borrow wETH debt within the legacy eMode upon implementation.
 

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -34,20 +34,9 @@ Reference: [[Risk Stewards]wstETH/wETH eMode Update - Ethereum, Arbitrum & Base 
 |       Parameter       |    Value     |
 | :-------------------: | :----------: |
 |         Asset         | wstETH, WETH |
-|        Max LTV        |     93.5     |
-| Liquidation Threshold |     95.5     |
+|        Max LTV        |     95.0     |
+| Liquidation Threshold |     96.5     |
 |  Liquidation Penalty  |    1.00%     |
-
-#### New wstETH/wETH v3.2 liquid eMode
-
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | wstETH | WETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 95.00% |   -   |
-| Liquidation Threshold | 96.50% |   -   |
-|  Liquidation Penalty  | 1.00%  |   -   |
 
 Complimenting the abundance of USDS liquidity provided by the Sky Ecosystem via D3M, this publication proposes increasing the LTV and LT on Prime to improve the capital efficiency of WETH and wstETH relative to other instances of Aave v3. With the support of Sky via D3M and Gho Stewards via Direct Gho Minter Facilitator providing liquidity on demand, the Prime instance is able to offer consistent stablecoin supply and less volatile borrow rates to users.
 
@@ -206,9 +195,7 @@ The following adjustments are to be implemented on all instances within the same
 
 ### Prime - Ethereum
 
-The Prime instance has the highest LTV/LT for ETH correlated assets.
-
-Pause the current wstETH/wETH Legacy eMode Update
+Update the current wstETH/wETH eMode
 
 |       Parameter       |    Value     |
 | :-------------------: | :----------: |
@@ -216,31 +203,6 @@ Pause the current wstETH/wETH Legacy eMode Update
 |        Max LTV        |     95.0     |
 | Liquidation Threshold |     96.5     |
 |  Liquidation Penalty  |    1.00%     |
-
-Update WETH LTV and LT Parameters
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    | 82.00%  |  84.00%  |
-|    LT     | 83.00%  |  85.00%  |
-
-Update wstETH LTV and LT Parameters
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    | 80.00%  |  82.00%  |
-|    LT     | 81.00%  |  83.00%  |
-
-Create new v3.2 liquid eMode
-
-|       Parameter       | Value  | Value |
-| :-------------------: | :----: | :---: |
-|         Asset         | wstETH | WETH  |
-|      Collateral       |  Yes   |  No   |
-|      Borrowable       |   No   |  Yes  |
-|        Max LTV        | 95.00% |   -   |
-| Liquidation Threshold | 96.50% |   -   |
-|  Liquidation Penalty  | 1.00%  |   -   |
 
 Create new v3.2 liquid eMode
 
@@ -257,27 +219,27 @@ Create new v3.2 liquid eMode
 
 rsETH/wstETH liquid eMode update.
 
-|       Parameter       |      Value      | Value  |
-| :-------------------: | :-------------: | :----: |
-|         Asset         |      rsETH      | wstETH |
-|      Collateral       |       Yes       |   No   |
-|      Borrowable       |       No        |  Yes   |
-|        Max LTV        | ~~92.5~~ 93.00% |   -    |
-| Liquidation Threshold | ~~94.5~~ 95.00% |   -    |
-|  Liquidation Penalty  |      1.00%      |   -    |
+|       Parameter       | Value  | Value  |
+| :-------------------: | :----: | :----: |
+|         Asset         | rsETH  | wstETH |
+|      Collateral       |  Yes   |   No   |
+|      Borrowable       |   No   |  Yes   |
+|        Max LTV        | 93.00% |   -    |
+| Liquidation Threshold | 95.00% |   -    |
+|  Liquidation Penalty  | 1.00%  |   -    |
 
 ### Arbitrum
 
 rsETH/wstETH liquid eMode update.
 
-|       Parameter       |      Value      | Value  |
-| :-------------------: | :-------------: | :----: |
-|         Asset         |      rsETH      | wstETH |
-|      Collateral       |       Yes       |   No   |
-|      Borrowable       |       No        |  Yes   |
-|        Max LTV        | ~~92.5~~ 93.00% |   -    |
-| Liquidation Threshold | ~~94.5~~ 95.00% |   -    |
-|  Liquidation Penalty  |      1.00%      |   -    |
+|       Parameter       | Value  | Value  |
+| :-------------------: | :----: | :----: |
+|         Asset         | rsETH  | wstETH |
+|      Collateral       |  Yes   |   No   |
+|      Borrowable       |   No   |  Yes   |
+|        Max LTV        | 93.00% |   -    |
+| Liquidation Threshold | 95.00% |   -    |
+|  Liquidation Penalty  | 1.00%  |   -    |
 
 Create new v3.2 liquid eMode
 
@@ -290,25 +252,18 @@ Create new v3.2 liquid eMode
 | Liquidation Threshold | 75.00% |   -   |   -   |
 |  Liquidation Penalty  | 7.50%  |   -   |   -   |
 
-weETH LTV/LT Update.
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    |  72.5%  |   75%    |
-|    LT     |   75%   |   77%    |
-
 ### Base
 
-rsETH/wstETH liquid eMode, no change.
+Update rsETH/wstETH liquid eMode.
 
-|       Parameter       |      Value      | Value  |
-| :-------------------: | :-------------: | :----: |
-|         Asset         |      rsETH      | wstETH |
-|      Collateral       |       Yes       |   No   |
-|      Borrowable       |       No        |  Yes   |
-|        Max LTV        | ~~92.5~~ 93.00% |   -    |
-| Liquidation Threshold | ~~94.5~~ 95.00% |   -    |
-|  Liquidation Penalty  |      1.00%      |   -    |
+|       Parameter       | Value  | Value  |
+| :-------------------: | :----: | :----: |
+|         Asset         | rsETH  | wstETH |
+|      Collateral       |  Yes   |   No   |
+|      Borrowable       |   No   |  Yes   |
+|        Max LTV        | 93.00% |   -    |
+| Liquidation Threshold | 95.00% |   -    |
+|  Liquidation Penalty  | 1.00%  |   -    |
 
 Create new v3.2 liquid eMode
 
@@ -332,7 +287,7 @@ Create weETH/wETH liquid eMode.
 | Liquidation Threshold | 95.00% |   -   |
 |  Liquidation Penalty  | 1.25%  |   -   |
 
-Create wstETH/WETH eMode Update
+Create wstETH/WETH eMode
 
 |       Parameter       | Value  | Value |
 | :-------------------: | :----: | :---: |
@@ -354,14 +309,7 @@ Create cbETH/WETH eMode Update
 | Liquidation Threshold | 95.00% |   -   |
 |  Liquidation Penalty  | 2.00%  |   -   |
 
-Pause the existing eMode by disabling wETH Borrowing within existing eMode. Users will no be able to borrow wETH debt within the legacy eMode upon implementation.
-
-weETH LTV/LT Update.
-
-| Parameter | Current | Proposed |
-| :-------: | :-----: | :------: |
-|    LTV    |  72.5%  |   75%    |
-|    LT     |   75%   |   77%    |
+Pause the existing eMode by disabling wETH Borrowing within existing eMode. Users will not be able to borrow wETH debt within the legacy eMode upon implementation.
 
 ## References
 

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -213,8 +213,8 @@ Pause the current wstETH/wETH Legacy eMode Update
 |       Parameter       |    Value     |
 | :-------------------: | :----------: |
 |         Asset         | wstETH, WETH |
-|        Max LTV        |     93.5     |
-| Liquidation Threshold |     95.5     |
+|        Max LTV        |     95.0     |
+| Liquidation Threshold |     96.5     |
 |  Liquidation Penalty  |    1.00%     |
 
 Update WETH LTV and LT Parameters

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -1,0 +1,375 @@
+---
+title: "LRT and wstETH Unification"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739"
+---
+
+## Simple Summary
+
+This publication presents a comprehensive overview of proposed LRT and LST risk parameters updates across Ethereum, Prime, Base and Arbitrum instances of Aave v3.
+
+## Motivation
+
+This publication incorporates the feedback and recent discussions into a single holistic publication. For ease of reference, those publications are referenced below:
+
+- [[ARFC] wstETH and weETH E-Modes and LT/LTV Adjustments on Ethereum, Arbitrum, Base - 03.12.25](https://governance.aave.com/t/arfc-wsteth-and-weeth-e-modes-and-lt-ltv-adjustments-on-ethereum-arbitrum-base-03-12-25/21370)
+- [[ARFC] rsETH LTV & LT Update](https://governance.aave.com/t/arfc-rseth-ltv-lt-update/21305)
+- [[ARFC] Core Instance - Add ezETH and update rsETH eMode Parameters](https://governance.aave.com/t/arfc-core-instance-add-ezeth-and-update-rseth-emode-parameters/21505)
+- [[Risk Stewards]wstETH/wETH eMode Update - Ethereum, Arbitrum & Base Instances](https://governance.aave.com/t/risk-stewards-wsteth-weth-emode-update-ethereum-arbitrum-base-instances/21333)
+
+Each of the following sub-sections presents insights into how each parameter is to be adjusted.
+
+### Prime Instance - wstETH and WETH eMode
+
+The Prime instance, previously Lido instance, presents a tailored wstETH eMode configuration that offers enhanced capital efficiency relative to other instances of Aave v3. With a Liquidation Threshold (LT) of 96.50% for wstETH on Prime relative to 95.00% elsewhere, a position with a Health Factor of 1.01 can support a leverage ratio of 22.44 on Prime relative to 16.83 on other instances of Aave Protocol.
+
+With all other variables held constant, a small difference in the wstETH deposit yield on Prime relative to the Core instance, has a meaningful impact on the overall return of the wstETH/WETH yield strategy. With a strong focus on sustaining a wstETH deposit yield derived from LRT/wstETH leverage, the wstETH/WETH yield strategy is expected to outperform on Prime relative to other venues supporting the same wstETH/WETH strategy.
+
+Provided suitable ETH liquidity is available, implementing favourable eMode terms on Prime relative to other instances of Aave is expected to lead to significant growth in wstETH deposits. A LT of 96.50% exceeds the previous forum discussion supportive of implementing a 96.00% LT, whilst also isolating the LT increase specifically to the Prime instance that reflects a clear focus to progress Prime into a sustainable ETH correlated instance of Aave v3.
+
+Reference: [[Risk Stewards]wstETH/wETH eMode Update - Ethereum, Arbitrum & Base Instances](https://governance.aave.com/t/risk-stewards-wsteth-weth-emode-update-ethereum-arbitrum-base-instances/21333)
+
+#### wstETH/wETH Legacy eMode Update
+
+|       Parameter       |    Value     |
+| :-------------------: | :----------: |
+|         Asset         | wstETH, WETH |
+|        Max LTV        |     93.5     |
+| Liquidation Threshold |     95.5     |
+|  Liquidation Penalty  |    1.00%     |
+
+#### New wstETH/wETH v3.2 liquid eMode
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | wstETH | WETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 95.00% |   -   |
+| Liquidation Threshold | 96.50% |   -   |
+|  Liquidation Penalty  | 1.00%  |   -   |
+
+Complimenting the abundance of USDS liquidity provided by the Sky Ecosystem via D3M, this publication proposes increasing the LTV and LT on Prime to improve the capital efficiency of WETH and wstETH relative to other instances of Aave v3. With the support of Sky via D3M and Gho Stewards via Direct Gho Minter Facilitator providing liquidity on demand, the Prime instance is able to offer consistent stablecoin supply and less volatile borrow rates to users.
+
+The combination of improved capital efficiency and less volatile borrow rates elevates the competitive positioning of the Prime instances within the broader ecosystem.
+
+#### WETH LTV/LT Update
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    | 82.00%  |  84.00%  |
+|    LT     | 83.00%  |  85.00%  |
+
+#### wstETH LTV/LT Update
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    | 80.00%  |  82.00%  |
+|    LT     | 81.00%  |  83.00%  |
+
+### rsETH LTV & LT Update
+
+To promote a level playing field between LRTs, a proposal was submitted and approved by Risk Service Providers to align the LTV and LT parameters of rsETH with other LRTs, ezETH and weETH.
+
+The following is proposed for rsETH Core, Prime and Base instances:
+
+- Update rsETH/wstETH eMode: LTV 93%, LT 95% and Liquidation Penalty 1%.
+
+A previous forum post details favourable feedback from Risk Service providers supporting amending the LTV and LT to align with other LRTs.
+
+Reference: [[ARFC] rsETH LTV & LT Update](https://governance.aave.com/t/arfc-rseth-ltv-lt-update/21305/1)
+
+#### rsETH/wstETH eMode Update
+
+(Prime, Core, Arbitrum and Base)
+
+|       Parameter       | Value  | Value  |
+| :-------------------: | :----: | :----: |
+|         Asset         | rsETH  | wstETH |
+|      Collateral       |  Yes   |   No   |
+|      Borrowable       |   No   |  Yes   |
+|        Max LTV        | 93.00% |   -    |
+| Liquidation Threshold | 95.00% |   -    |
+|  Liquidation Penalty  | 1.00%  |   -    |
+
+Enable rsETH to access stablecoin liquidity on Prime, Arbitrum and Base instances.
+
+#### Create new v3.2 liquid eMode
+
+(Prime)
+
+|       Parameter       | Value  | Value | Value | Value |
+| :-------------------: | :----: | :---: | :---: | :---: |
+|         Asset         | rsETH  | USDS  | USDC  |  GHO  |
+|      Collateral       |  Yes   |  No   |  No   |  No   |
+|      Borrowable       |   No   |  Yes  |  Yes  |  Yes  |
+|        Max LTV        | 72.00% |   -   |   -   |   -   |
+| Liquidation Threshold | 75.00% |   -   |   -   |   -   |
+|  Liquidation Penalty  | 7.50%  |   -   |   -   |   -   |
+
+#### Create new v3.2 liquid eMode
+
+(Arbitrum)
+
+|       Parameter       | Value  | Value | Value |
+| :-------------------: | :----: | :---: | :---: |
+|         Asset         | rsETH  | USDC  | USDT  |
+|      Collateral       |  Yes   |  No   |  No   |
+|      Borrowable       |   No   |  Yes  |  Yes  |
+|        Max LTV        | 72.00% |   -   |   -   |
+| Liquidation Threshold | 75.00% |   -   |   -   |
+|  Liquidation Penalty  | 7.50%  |   -   |   -   |
+
+#### Create new v3.2 liquid eMode
+
+(Base)
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | rsETH  | USDC  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 72.00% |   -   |
+| Liquidation Threshold | 75.00% |   -   |
+|  Liquidation Penalty  | 7.50%  |   -   |
+
+### weETH LTV & LT Update
+
+Based upon improving liquidity conditions on both Arbitrum and Base for weETH, this publication proposes increasing the weETH LTV and LTV as recommended by the Chaos Labs and Llama Risk in the reference linked below.
+
+#### weETH LTV/LT Update
+
+(Arb and Base)
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    |  72.5%  |   75%    |
+|    LT     |   75%   |   77%    |
+
+Reference: [[ARFC] wstETH and weETH E-Modes and LT/LTV Adjustments on Ethereum, Arbitrum, Base - 03.12.25](https://governance.aave.com/t/arfc-wsteth-and-weeth-e-modes-and-lt-ltv-adjustments-on-ethereum-arbitrum-base-03-12-25/21370)
+
+### Base Instance - Liquid eMode v3.2
+
+The introduction of Liquid eModes in Aave v3.2 enables more granular and targeted risk configurations between correlated assets such as LSTs and LRTs. Creating isolated eModes for each pair enhances capital efficiency relative to the current ETH-correlated eModes on the Base instance.
+
+Currently, Aave Protocol supports a single ETH Correlated eMode on Base.
+
+|       Parameter       |           Value            |
+| :-------------------: | :------------------------: |
+|         Asset         | weETH, wstETH, cbETH, WETH |
+|        Max LTV        |           90.00%           |
+| Liquidation Threshold |           93.00%           |
+|  Liquidation Penalty  |           2.00%            |
+
+To align the asset parameter configuration on Base instance with other instances of Aave, new v3.2 Liquid eModes are to be deployed with the following parameters. Each new eMode reflects the LTV and LT in use on the Core instance on Ethereum and in doing so unifies the parameters across Core, Arb and Base. Furthermore, by pausing the existing ETH correlated eMode and transitioning to more capital efficient v3.2 eModes, it prevents same-asset looping that undermines liquidity incentives from unintended utilisation.
+
+#### weETH/WETH eMode Update
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | weETH  | wETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 93.00% |   -   |
+| Liquidation Threshold | 95.00% |   -   |
+|  Liquidation Penalty  | 1.25%  |   -   |
+
+#### wstETH/WETH eMode Update
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | wstETH | wETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 93.00% |   -   |
+| Liquidation Threshold | 95.00% |   -   |
+|  Liquidation Penalty  | 1.00%  |   -   |
+
+#### cbETH/WETH eMode Update
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | cbETH  | wETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 93.00% |   -   |
+| Liquidation Threshold | 95.00% |   -   |
+|  Liquidation Penalty  | 2.00%  |   -   |
+
+The above new weETH eModes incorporates the feedback from the forum discussion linked below.
+
+Reference: [[ARFC] wstETH and weETH E-Modes and LT/LTV Adjustments on Ethereum, Arbitrum, Base - 03.12.25](https://governance.aave.com/t/arfc-wsteth-and-weeth-e-modes-and-lt-ltv-adjustments-on-ethereum-arbitrum-base-03-12-25/21370)
+
+## Specification
+
+The following adjustments are to be implemented on all instances within the same AIP.
+
+### Prime - Ethereum
+
+The Prime instance has the highest LTV/LT for ETH correlated assets.
+
+Pause the current wstETH/wETH Legacy eMode Update
+
+|       Parameter       |    Value     |
+| :-------------------: | :----------: |
+|         Asset         | wstETH, WETH |
+|        Max LTV        |     93.5     |
+| Liquidation Threshold |     95.5     |
+|  Liquidation Penalty  |    1.00%     |
+
+Update WETH LTV and LT Parameters
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    | 82.00%  |  84.00%  |
+|    LT     | 83.00%  |  85.00%  |
+
+Update wstETH LTV and LT Parameters
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    | 80.00%  |  82.00%  |
+|    LT     | 81.00%  |  83.00%  |
+
+Create new v3.2 liquid eMode
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | wstETH | WETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 95.00% |   -   |
+| Liquidation Threshold | 96.50% |   -   |
+|  Liquidation Penalty  | 1.00%  |   -   |
+
+Create new v3.2 liquid eMode
+
+|       Parameter       | Value  | Value | Value | Value |
+| :-------------------: | :----: | :---: | :---: | :---: |
+|         Asset         | rsETH  | USDS  | USDC  |  GHO  |
+|      Collateral       |  Yes   |  No   |  No   |  No   |
+|      Borrowable       |   No   |  Yes  |  Yes  |  Yes  |
+|        Max LTV        | 72.00% |   -   |   -   |   -   |
+| Liquidation Threshold | 75.00% |   -   |   -   |   -   |
+|  Liquidation Penalty  | 7.50%  |   -   |   -   |   -   |
+
+### Core - Ethereum
+
+rsETH/wstETH liquid eMode update.
+
+|       Parameter       |      Value      | Value  |
+| :-------------------: | :-------------: | :----: |
+|         Asset         |      rsETH      | wstETH |
+|      Collateral       |       Yes       |   No   |
+|      Borrowable       |       No        |  Yes   |
+|        Max LTV        | ~~92.5~~ 93.00% |   -    |
+| Liquidation Threshold | ~~94.5~~ 95.00% |   -    |
+|  Liquidation Penalty  |      1.00%      |   -    |
+
+### Arbitrum
+
+rsETH/wstETH liquid eMode update.
+
+|       Parameter       |      Value      | Value  |
+| :-------------------: | :-------------: | :----: |
+|         Asset         |      rsETH      | wstETH |
+|      Collateral       |       Yes       |   No   |
+|      Borrowable       |       No        |  Yes   |
+|        Max LTV        | ~~92.5~~ 93.00% |   -    |
+| Liquidation Threshold | ~~94.5~~ 95.00% |   -    |
+|  Liquidation Penalty  |      1.00%      |   -    |
+
+Create new v3.2 liquid eMode
+
+|       Parameter       | Value  | Value | Value |
+| :-------------------: | :----: | :---: | :---: |
+|         Asset         | rsETH  | USDC  | USDT  |
+|      Collateral       |  Yes   |  No   |  No   |
+|      Borrowable       |   No   |  Yes  |  Yes  |
+|        Max LTV        | 72.00% |   -   |   -   |
+| Liquidation Threshold | 75.00% |   -   |   -   |
+|  Liquidation Penalty  | 7.50%  |   -   |   -   |
+
+weETH LTV/LT Update.
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    |  72.5%  |   75%    |
+|    LT     |   75%   |   77%    |
+
+### Base
+
+rsETH/wstETH liquid eMode, no change.
+
+|       Parameter       |      Value      | Value  |
+| :-------------------: | :-------------: | :----: |
+|         Asset         |      rsETH      | wstETH |
+|      Collateral       |       Yes       |   No   |
+|      Borrowable       |       No        |  Yes   |
+|        Max LTV        | ~~92.5~~ 93.00% |   -    |
+| Liquidation Threshold | ~~94.5~~ 95.00% |   -    |
+|  Liquidation Penalty  |      1.00%      |   -    |
+
+Create new v3.2 liquid eMode
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | rsETH  | USDC  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 72.00% |   -   |
+| Liquidation Threshold | 75.00% |   -   |
+|  Liquidation Penalty  | 7.50%  |   -   |
+
+Create weETH/wETH liquid eMode.
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | weETH  | wETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 93.00% |   -   |
+| Liquidation Threshold | 95.00% |   -   |
+|  Liquidation Penalty  | 1.25%  |   -   |
+
+Create wstETH/WETH eMode Update
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | wstETH | wETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 93.00% |   -   |
+| Liquidation Threshold | 95.00% |   -   |
+|  Liquidation Penalty  | 1.00%  |   -   |
+
+Create cbETH/WETH eMode Update
+
+|       Parameter       | Value  | Value |
+| :-------------------: | :----: | :---: |
+|         Asset         | cbETH  | wETH  |
+|      Collateral       |  Yes   |  No   |
+|      Borrowable       |   No   |  Yes  |
+|        Max LTV        | 93.00% |   -   |
+| Liquidation Threshold | 95.00% |   -   |
+|  Liquidation Penalty  | 2.00%  |   -   |
+
+Pause the existing eMode by disabling wETH Borrowing within existing eMode. Users will no be able to borrow wETH debt within the legacy eMode upon implementation.
+
+weETH LTV/LT Update.
+
+| Parameter | Current | Proposed |
+| :-------: | :-----: | :------: |
+|    LTV    |  72.5%  |   75%    |
+|    LT     |   75%   |   77%    |
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol), [AaveV3EthereumLido](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol), [AaveV3Arbitrum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol), [AaveV3Base](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.t.sol), [AaveV3EthereumLido](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.t.sol), [AaveV3Arbitrum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.t.sol), [AaveV3Base](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.t.sol)
+- Snapshot: Direct-to-AIP
+- [Discussion](https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -59,8 +59,6 @@ Create new v3.2 liquid eMode
 |       Parameter       |      Value      |
 | :-------------------: | :-------------: |
 |         Asset         |      rsETH      |
-|      Collateral       |       Yes       |
-|      Borrowable       |       No        |
 |        Max LTV        |     72.00%      |
 | Liquidation Threshold |     75.00%      |
 |  Liquidation Penalty  |      7.50%      |
@@ -74,8 +72,6 @@ rsETH/wstETH liquid eMode update.
 |       Parameter       |    Value     |
 | :-------------------: | :----------: |
 |         Asset         |    rsETH     |
-|      Collateral       |     Yes      |
-|      Borrowable       |      No      |
 |        Max LTV        |    93.00%    |
 | Liquidation Threshold |    95.00%    |
 |  Liquidation Penalty  |    1.00%     |
@@ -89,8 +85,6 @@ rsETH/wstETH liquid eMode update.
 |       Parameter       | Value  |
 | :-------------------: | :----: |
 |         Asset         | rsETH  |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.00%  |
@@ -102,8 +96,6 @@ Create new v3.2 liquid eMode
 |       Parameter       |   Value    |
 | :-------------------: | :--------: |
 |         Asset         |   rsETH    |
-|      Collateral       |    Yes     |
-|      Borrowable       |     No     |
 |        Max LTV        |   72.00%   |
 | Liquidation Threshold |   75.00%   |
 |  Liquidation Penalty  |   7.50%    |
@@ -117,8 +109,6 @@ Update rsETH/wstETH liquid eMode.
 |       Parameter       | Value  |
 | :-------------------: | :----: |
 |         Asset         | rsETH  |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.00%  |
@@ -130,8 +120,6 @@ Create new v3.2 liquid eMode
 |       Parameter       | Value  |
 | :-------------------: | :----: |
 |         Asset         | rsETH  |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
 |        Max LTV        | 72.00% |
 | Liquidation Threshold | 75.00% |
 |  Liquidation Penalty  | 7.50%  |
@@ -143,8 +131,6 @@ Create weETH/wETH liquid eMode.
 |       Parameter       | Value  |
 | :-------------------: | :----: |
 |         Asset         | weETH  |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.25%  |
@@ -156,8 +142,6 @@ Create wstETH/WETH eMode
 |       Parameter       | Value  |
 | :-------------------: | :----: |
 |         Asset         | wstETH |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 1.00%  |
@@ -169,8 +153,6 @@ Create cbETH/WETH eMode Update
 |       Parameter       | Value  |
 | :-------------------: | :----: |
 |         Asset         | cbETH  |
-|      Collateral       |  Yes   |
-|      Borrowable       |   No   |
 |        Max LTV        | 93.00% |
 | Liquidation Threshold | 95.00% |
 |  Liquidation Penalty  | 2.00%  |

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md
@@ -175,8 +175,6 @@ Create cbETH/WETH eMode Update
 |      Collaterals      | cbETH  |
 |      Borrowable       |  wETH  |
 
-Pause the existing eMode by disabling wETH Borrowing within existing eMode. Users will not be able to borrow wETH debt within the legacy eMode upon implementation.
-
 ## References
 
 - Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol), [AaveV3EthereumLido](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol), [AaveV3Arbitrum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol), [AaveV3Base](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250430_Multi_LRTAndWstETHUnification/AaveV3Base_LRTAndWstETHUnification_20250430.sol)

--- a/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification_20250430.s.sol
+++ b/src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification_20250430.s.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript, ArbitrumScript, BaseScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_LRTAndWstETHUnification_20250430} from './AaveV3Ethereum_LRTAndWstETHUnification_20250430.sol';
+import {AaveV3EthereumLido_LRTAndWstETHUnification_20250430} from './AaveV3EthereumLido_LRTAndWstETHUnification_20250430.sol';
+import {AaveV3Arbitrum_LRTAndWstETHUnification_20250430} from './AaveV3Arbitrum_LRTAndWstETHUnification_20250430.sol';
+import {AaveV3Base_LRTAndWstETHUnification_20250430} from './AaveV3Base_LRTAndWstETHUnification_20250430.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification_20250430.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/LRTAndWstETHUnification_20250430.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_LRTAndWstETHUnification_20250430).creationCode
+    );
+    address payload1 = GovV3Helpers.deployDeterministic(
+      type(AaveV3EthereumLido_LRTAndWstETHUnification_20250430).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](2);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+    actions[1] = GovV3Helpers.buildAction(payload1);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Deploy Arbitrum
+ * deploy-command: make deploy-ledger contract=src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification_20250430.s.sol:DeployArbitrum chain=arbitrum
+ * verify-command: FOUNDRY_PROFILE=arbitrum npx catapulta-verify -b broadcast/LRTAndWstETHUnification_20250430.s.sol/42161/run-latest.json
+ */
+contract DeployArbitrum is ArbitrumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Arbitrum_LRTAndWstETHUnification_20250430).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Deploy Base
+ * deploy-command: make deploy-ledger contract=src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification_20250430.s.sol:DeployBase chain=base
+ * verify-command: FOUNDRY_PROFILE=base npx catapulta-verify -b broadcast/LRTAndWstETHUnification_20250430.s.sol/8453/run-latest.json
+ */
+contract DeployBase is BaseScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Base_LRTAndWstETHUnification_20250430).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification_20250430.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](3);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](2);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3Ethereum_LRTAndWstETHUnification_20250430).creationCode
+    );
+    actionsEthereum[1] = GovV3Helpers.buildAction(
+      type(AaveV3EthereumLido_LRTAndWstETHUnification_20250430).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsArbitrum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsArbitrum[0] = GovV3Helpers.buildAction(
+      type(AaveV3Arbitrum_LRTAndWstETHUnification_20250430).creationCode
+    );
+    payloads[1] = GovV3Helpers.buildArbitrumPayload(vm, actionsArbitrum);
+
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsBase = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsBase[0] = GovV3Helpers.buildAction(
+      type(AaveV3Base_LRTAndWstETHUnification_20250430).creationCode
+    );
+    payloads[2] = GovV3Helpers.buildBasePayload(vm, actionsBase);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20250430_Multi_LRTAndWstETHUnification/LRTAndWstETHUnification.md'
+      )
+    );
+  }
+}

--- a/src/20250430_Multi_LRTAndWstETHUnification/config.ts
+++ b/src/20250430_Multi_LRTAndWstETHUnification/config.ts
@@ -1,0 +1,19 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum', 'AaveV3EthereumLido', 'AaveV3Arbitrum', 'AaveV3Base'],
+    title: 'LRT and wstETH Unification',
+    shortName: 'LRTAndWstETHUnification',
+    date: '20250430',
+    author: '@TokenLogic',
+    discussion: 'https://governance.aave.com/t/arfc-lrt-and-wsteth-unification/21739',
+    snapshot: 'Direct-to-AIP',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {configs: {OTHERS: {}}, cache: {blockNumber: 22377625}},
+    AaveV3EthereumLido: {configs: {OTHERS: {}}, cache: {blockNumber: 22377625}},
+    AaveV3Arbitrum: {configs: {OTHERS: {}}, cache: {blockNumber: 331579415}},
+    AaveV3Base: {configs: {OTHERS: {}}, cache: {blockNumber: 29587769}},
+  },
+};


### PR DESCRIPTION
# Changelog

Update eModes and add new ones across Mainnet, Prime, Base and Arbitrum.

## Question

Is there a way to disable an existing eMode so that it doesn't affect current users but disabled for others?
RLUSD gives NotActivated on the defaultTest with the current set up, have you run into this?